### PR TITLE
Wasm macros and RLP encoding

### DIFF
--- a/libraries/platonlib/include/platon/RLP.h
+++ b/libraries/platonlib/include/platon/RLP.h
@@ -67,22 +67,7 @@ namespace platon
         RLP() {}
 
         /// Construct a node of value given in the bytes.
-        explicit RLP(bytesConstRef _d, Strictness _s = VeryStrict) : m_data(_d) {
-            if ((_s & FailIfTooBig) && actualSize() < _d.size())
-            {
-                if (_s & ThrowOnFail)
-                    platonThrow("over size rlp");
-                else
-                    m_data.reset();
-            }
-            if ((_s & FailIfTooSmall) && actualSize() > _d.size())
-            {
-                if (_s & ThrowOnFail)
-                    platonThrow("under size rlp");
-                else
-                    m_data.reset();
-            }
-        }
+        explicit RLP(bytesConstRef _d, Strictness _s = VeryStrict);
 
         /// Construct a node of value given in the bytes.
         explicit RLP(bytes const& _d, Strictness _s = VeryStrict): RLP(&_d, _s) {}
@@ -112,31 +97,7 @@ namespace platon
         bool isList() const { return !isNull() && m_data[0] >= c_rlpListStart; }
 
         /// Integer value. Must not have a leading zero.
-        bool isInt() const {
-            if (isNull())
-                return false;
-            requireGood();
-            byte n = m_data[0];
-            if (n < c_rlpDataImmLenStart)
-                return !!n;
-            else if (n == c_rlpDataImmLenStart)
-                return true;
-            else if (n <= c_rlpDataIndLenZero)
-            {
-                if (m_data.size() <= 1)
-                    platonThrow("bad rlp");
-                return m_data[1] != 0;
-            }
-            else if (n < c_rlpListStart)
-            {
-                if (m_data.size() <= size_t(1 + n - c_rlpDataIndLenZero))
-                    platonThrow("bad rlp");
-                return m_data[1 + n - c_rlpDataIndLenZero] != 0;
-            }
-            else
-                return false;
-            return false;
-        }
+        bool isInt() const;
 
         /// @returns the number of items in the list, or zero if it isn't a list.
         size_t itemCount() const { return isList() ? items() : 0; }
@@ -163,21 +124,7 @@ namespace platon
         /// Subscript operator.
         /// @returns the list item @a _i if isList() and @a _i < listItems(), or RLP() otherwise.
         /// @note if used to access items in ascending order, this is efficient.
-        RLP operator[](size_t _i) const {
-            if (_i < m_lastIndex)
-            {
-                m_lastEnd = sizeAsEncoded(payload());
-                m_lastItem = payload().cropped(0, m_lastEnd);
-                m_lastIndex = 0;
-            }
-            for (; m_lastIndex < _i && m_lastItem.size(); ++m_lastIndex)
-            {
-                m_lastItem = payload().cropped(m_lastEnd);
-                m_lastItem = m_lastItem.cropped(0, sizeAsEncoded(m_lastItem));
-                m_lastEnd += m_lastItem.size();
-            }
-            return RLP(m_lastItem, int(ThrowOnFail) | int(FailIfTooSmall));
-        }
+        RLP operator[](size_t _i) const;
 
         using element_type = RLP;
 
@@ -190,17 +137,7 @@ namespace platon
             using value_type = RLP;
             using element_type = RLP;
 
-            iterator& operator++() {
-                if (m_remaining)
-                {
-                    m_currentItem.retarget(m_currentItem.next().data(), m_remaining);
-                    m_currentItem = m_currentItem.cropped(0, sizeAsEncoded(m_currentItem));
-                    m_remaining -= std::min<size_t>(m_remaining, m_currentItem.size());
-                }
-                else
-                    m_currentItem.retarget(m_currentItem.next().data(), 0);
-                return *this;
-            }
+            iterator& operator++();
             iterator operator++(int) { auto ret = *this; operator++(); return ret; }
             RLP operator*() const { return RLP(m_currentItem); }
             bool operator==(iterator const& _cmp) const { return m_currentItem == _cmp.m_currentItem; }
@@ -208,19 +145,7 @@ namespace platon
 
         private:
             iterator() {}
-            iterator(RLP const& _parent, bool _begin) {
-                if (_begin && _parent.isList())
-                {
-                    auto pl = _parent.payload();
-                    m_currentItem = pl.cropped(0, sizeAsEncoded(pl));
-                    m_remaining = pl.size() - m_currentItem.size();
-                }
-                else
-                {
-                    m_currentItem = _parent.data().cropped(_parent.data().size());
-                    m_remaining = 0;
-                }
-            }
+            iterator(RLP const& _parent, bool _begin);
 
             size_t m_remaining = 0;
             bytesConstRef m_currentItem;
@@ -386,33 +311,13 @@ namespace platon
 
         /// @returns the theoretical size of this item as encoded in the data.
         /// @note Under normal circumstances, is equivalent to m_data.size() - use that unless you know it won't work.
-        size_t actualSize() const {
-            if (isNull())
-                return 0;
-            if (isSingleByte())
-                return 1;
-            if (isData() || isList())
-                return payloadOffset() + length();
-            return 0;
-        }
-
+        size_t actualSize() const;
     private:
         /// Disable construction from rvalue
         explicit RLP(bytes const&&) {}
 
         /// Throws if is non-canonical data (i.e. single byte done in two bytes that could be done in one).
-        void requireGood() const {
-            if (isNull())
-                platonThrow("bad rlp");
-            byte n = m_data[0];
-            if (n != c_rlpDataImmLenStart + 1)
-                return;
-            if (m_data.size() < 2)
-                platonThrow("bad rlp");
-            if (m_data[1] < c_rlpDataImmLenStart)
-                platonThrow("bad rlp");
-        }
-
+        void requireGood() const;
         /// Single-byte data payload.
         bool isSingleByte() const { return !isNull() && m_data[0] < c_rlpDataImmLenStart; }
 
@@ -420,78 +325,13 @@ namespace platon
         unsigned lengthSize() const { if (isData() && m_data[0] > c_rlpDataIndLenZero) return m_data[0] - c_rlpDataIndLenZero; if (isList() && m_data[0] > c_rlpListIndLenZero) return m_data[0] - c_rlpListIndLenZero; return 0; }
 
         /// @returns the size in bytes of the payload, as given by the RLP as opposed to as inferred from m_data.
-        size_t length() const {
-            if (isNull())
-                return 0;
-            requireGood();
-            size_t ret = 0;
-            byte const n = m_data[0];
-            if (n < c_rlpDataImmLenStart)
-                return 1;
-            else if (n <= c_rlpDataIndLenZero)
-                return n - c_rlpDataImmLenStart;
-            else if (n < c_rlpListStart)
-            {
-                if (m_data.size() <= size_t(n - c_rlpDataIndLenZero))
-                    platonThrow("bad rlp");
-                if (m_data.size() > 1)
-                    if (m_data[1] == 0)
-                        platonThrow("bad rlp");
-                unsigned lengthSize = n - c_rlpDataIndLenZero;
-                if (lengthSize > sizeof(ret))
-                    // We did not check, but would most probably not fit in our memory.
-                    platonThrow("under size rlp");
-                // No leading zeroes.
-                if (!m_data[1])
-                    platonThrow("bad rlp");
-                for (unsigned i = 0; i < lengthSize; ++i)
-                    ret = (ret << 8) | m_data[i + 1];
-                // Must be greater than the limit.
-                if (ret < c_rlpListStart - c_rlpDataImmLenStart - c_rlpMaxLengthBytes)
-                    platonThrow("bad rlp");
-            }
-            else if (n <= c_rlpListIndLenZero)
-                return n - c_rlpListStart;
-            else
-            {
-                unsigned lengthSize = n - c_rlpListIndLenZero;
-                if (m_data.size() <= lengthSize)
-                    platonThrow("bad rlp");
-                if (m_data.size() > 1)
-                    if (m_data[1] == 0)
-                        platonThrow("bad rlp");
-                if (lengthSize > sizeof(ret))
-                    // We did not check, but would most probably not fit in our memory.
-                    platonThrow("under size rlp");
-                if (!m_data[1])
-                    platonThrow("bad rlp");
-                for (unsigned i = 0; i < lengthSize; ++i)
-                    ret = (ret << 8) | m_data[i + 1];
-                if (ret < 0x100 - c_rlpListStart - c_rlpMaxLengthBytes)
-                    platonThrow("bad rlp");
-            }
-            // We have to be able to add payloadOffset to length without overflow.
-            // This rejects roughly 4GB-sized RLPs on some platforms.
-            if (ret >= std::numeric_limits<size_t>::max() - 0x100)
-                platonThrow("under size rlp");
-            return ret;
-        }
+        size_t length() const;
 
         /// @returns the number of bytes into the data that the payload starts.
         size_t payloadOffset() const { return isSingleByte() ? 0 : (1 + lengthSize()); }
 
         /// @returns the number of data items.
-        size_t items() const {
-            if (isList())
-            {
-                bytesConstRef d = payload();
-                size_t i = 0;
-                for (; d.size(); ++i)
-                    d = d.cropped(sizeAsEncoded(d));
-                return i;
-            }
-            return 0;
-        }
+        size_t items() const;
 
         /// @returns the size encoded into the RLP in @a _data and throws if _data is too short.
         static size_t sizeAsEncoded(bytesConstRef _data) { return RLP(_data, int(ThrowOnFail) | int(FailIfTooSmall)).actualSize(); }
@@ -541,48 +381,8 @@ public:
     RLPStream& append(unsigned _s) { return append(bigint(_s)); }
     RLPStream& append(u160 _s) { return append(bigint(_s)); }
     RLPStream& append(u256 _s) { return append(bigint(_s)); }
-    RLPStream& append(bigint _i) {
-        if (!_i)
-            m_out.push_back(c_rlpDataImmLenStart);
-        else if (_i < c_rlpDataImmLenStart)
-            m_out.push_back((byte)_i);
-        else
-        {
-            unsigned br = bytesRequired(_i);
-            if (br < c_rlpDataImmLenCount)
-                m_out.push_back((byte)(br + c_rlpDataImmLenStart));
-            else
-            {
-                auto brbr = bytesRequired(br);
-                if (c_rlpDataIndLenZero + brbr > 0xff)
-                    platonThrow("Number too large for RLP");
-                m_out.push_back((byte)(c_rlpDataIndLenZero + brbr));
-                pushInt(br, brbr);
-            }
-            pushInt(_i, br);
-        }
-        noteAppended();
-        return *this;
-    }
-    RLPStream& append(bytesConstRef _s, bool _compact = false) {
-        size_t s = _s.size();
-        byte const* d = _s.data();
-        if (_compact)
-            for (size_t i = 0; i < _s.size() && !*d; ++i, --s, ++d) {}
-
-        if (s == 1 && *d < c_rlpDataImmLenStart)
-            m_out.push_back(*d);
-        else
-        {
-            if (s < c_rlpDataImmLenCount)
-                m_out.push_back((byte)(s + c_rlpDataImmLenStart));
-            else
-                pushCount(s, c_rlpDataIndLenZero);
-            appendRaw(bytesConstRef(d, s), 0);
-        }
-        noteAppended();
-        return *this;
-    }
+    RLPStream& append(bigint _i);
+    RLPStream& append(bytesConstRef _s, bool _compact = false);
     RLPStream& append(bytes const& _s) { return append(bytesConstRef(&_s)); }
     RLPStream& append(std::string const& _s) { return append(bytesConstRef(_s)); }
     RLPStream& append(char const* _s) { return append(std::string(_s)); }
@@ -600,31 +400,13 @@ public:
     template <class T, class U> RLPStream& append(std::pair<T, U> const& _s) { appendList(2); append(_s.first); append(_s.second); return *this; }
 
     /// Appends a list.
-    RLPStream& appendList(size_t _items) {
-        //	cdebug << "appendList(" << _items << ")";
-        if (_items)
-            m_listStack.push_back(std::make_pair(_items, m_out.size()));
-        else
-            appendList(bytes());
-        return *this;
-    }
-    RLPStream& appendList(bytesConstRef _rlp) {
-        if (_rlp.size() < c_rlpListImmLenCount)
-            m_out.push_back((byte)(_rlp.size() + c_rlpListStart));
-        else
-            pushCount(_rlp.size(), c_rlpListIndLenZero);
-        appendRaw(_rlp, 1);
-        return *this;
-    }
+    RLPStream& appendList(size_t _items);
+    RLPStream& appendList(bytesConstRef _rlp);
     RLPStream& appendList(bytes const& _rlp) { return appendList(&_rlp); }
     RLPStream& appendList(RLPStream const& _s) { return appendList(&_s.out()); }
 
     /// Appends raw (pre-serialised) RLP data. Use with caution.
-    RLPStream& appendRaw(bytesConstRef _s, size_t _itemCount = 1) {
-        m_out.insert(m_out.end(), _s.begin(), _s.end());
-        noteAppended(_itemCount);
-        return *this;
-    }
+    RLPStream& appendRaw(bytesConstRef _s, size_t _itemCount = 1);
     RLPStream& appendRaw(bytes const& _rlp, size_t _itemCount = 1) { return appendRaw(&_rlp, _itemCount); }
 
     /// Shift operators for appending data items.
@@ -643,53 +425,11 @@ public:
     void swapOut(bytes& _dest) { if(!m_listStack.empty()) platonThrow("listStack is not empty"); swap(m_out, _dest); }
 
 private:
-    void noteAppended(size_t _itemCount = 1) {
-        if (!_itemCount)
-            return;
-    //	cdebug << "noteAppended(" << _itemCount << ")";
-        while (m_listStack.size())
-        {
-            if (m_listStack.back().first < _itemCount)
-                platonThrow("itemCount too large");
-            m_listStack.back().first -= _itemCount;
-            if (m_listStack.back().first)
-                break;
-            else
-            {
-                auto p = m_listStack.back().second;
-                m_listStack.pop_back();
-                size_t s = m_out.size() - p;		// list size
-                auto brs = bytesRequired(s);
-                unsigned encodeSize = s < c_rlpListImmLenCount ? 1 : (1 + brs);
-    //			cdebug << "s: " << s << ", p: " << p << ", m_out.size(): " << m_out.size() << ", encodeSize: " << encodeSize << " (br: " << brs << ")";
-                auto os = m_out.size();
-                m_out.resize(os + encodeSize);
-                memmove(m_out.data() + p + encodeSize, m_out.data() + p, os - p);
-                if (s < c_rlpListImmLenCount)
-                    m_out[p] = (byte)(c_rlpListStart + s);
-                else if (c_rlpListIndLenZero + brs <= 0xff)
-                {
-                    m_out[p] = (byte)(c_rlpListIndLenZero + brs);
-                    byte* b = &(m_out[p + brs]);
-                    for (; s; s >>= 8)
-                        *(b--) = (byte)s;
-                }
-                else
-                    platonThrow("itemCount too large for RLP");
-            }
-            _itemCount = 1;	// for all following iterations, we've effectively appended a single item only since we completed a list.
-        }
-    }
+    void noteAppended(size_t _itemCount = 1);
 
     /// Push the node-type byte (using @a _base) along with the item count @a _count.
     /// @arg _count is number of characters for strings, data-bytes for ints, or items for lists.
-    void pushCount(size_t _count, byte _base) {
-        auto br = bytesRequired(_count);
-        if (int(br) + _base > 0xff)
-            platonThrow("Count too large for RLP");
-        m_out.push_back((byte)(br + _base));	// max 8 bytes.
-        pushInt(_count, br);
-    }
+    void pushCount(size_t _count, byte _base);
 
     /// Push an integer as a raw big-endian byte-stream.
     template <class _T> void pushInt(_T _i, size_t _br)
@@ -733,4 +473,9 @@ template <class ... _Ts> bytes rlpList(_Ts ... _ts)
 /// Human readable version of RLP.
 //std::ostream& operator<<(std::ostream& _out, dev::RLP const& _d);
 
+}
+
+//get data from the RLP instance
+template <class T> void fetch(platon::RLP rlp, T &value){
+    value = T(rlp);
 }

--- a/libraries/platonlib/include/platon/contract.hpp
+++ b/libraries/platonlib/include/platon/contract.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
 #define PLATON_ABI(NAME, MEMBER)
-
-
+#define ACTION  __attribute__((annotate("action")))
+#define CONST  __attribute__((annotate("const")))
+#define CONTRACT class 
 
 namespace platon {
     class Contract {

--- a/libraries/platonlib/include/platon/dispatcher.hpp
+++ b/libraries/platonlib/include/platon/dispatcher.hpp
@@ -1,0 +1,110 @@
+#pragma once
+
+#include "boost/preprocessor/seq/for_each.hpp"
+#include "boost/fusion/algorithm/iteration/for_each.hpp"
+#include <boost/fusion/include/for_each.hpp>
+#include <boost/fusion/adapted/std_tuple.hpp>
+#include <boost/fusion/include/std_tuple.hpp>
+
+#include <boost/mp11/tuple.hpp>
+
+#include <boost/mp11/tuple.hpp>
+
+#include <platon/service.hpp>
+#include <type_traits>
+#include <tuple>
+#include<platon/RLP.h>
+
+namespace platon {
+
+    template<typename... Args>
+    void get_para(RLP& rlp, std::tuple<Args...>& t ) {
+        int vect_index = 1;
+        boost::fusion::for_each( t, [&]( auto& i ) {
+            fetch(rlp[vect_index], i);
+            vect_index++;
+        });
+    }
+
+	template<typename T>
+	void platon_return(const T &t);
+     /**
+    * Unpack the received action and execute the correponding action handler
+    *
+    * @tparam T - The contract class that has the correponding action handler, this contract should be derived from ontio::contract
+    * @tparam Q - The namespace of the action handler function
+    * @tparam Args - The arguments that the action handler accepts, i.e. members of the action
+    * @param obj - The contract object that has the correponding action handler
+    * @param func - The action handler
+    * @return true
+    */
+   template<typename T, typename R, typename... Args>
+   void execute_action( RLP& rlp,  R (T::*func)(Args...)  ) {
+      std::tuple<std::decay_t<Args>...> args;
+      get_para(rlp, args);
+
+      T inst;
+
+      auto f2 = [&]( auto... a ) {
+         R&& t = ((&inst)->*func)( a... );
+		 platon_return<R>(t);
+      };
+
+      boost::mp11::tuple_apply( f2, args );
+   }
+
+   template<typename T, typename... Args>
+   void execute_action(RLP& rlp, void (T::*func)(Args...)  ) {
+      std::tuple<std::decay_t<Args>...> args;
+      get_para(rlp, args);
+
+      T inst;
+
+      auto f2 = [&]( auto... a ) {
+         ((&inst)->*func)( a... );
+      };
+
+      boost::mp11::tuple_apply( f2, args );
+   }
+
+    // Helper macro for EOSIO_DISPATCH_INTERNAL
+    #define PLATON_DISPATCH_INTERNAL( r, OP, elem ) \
+	    else if ( method == BOOST_PP_STRINGIZE(elem) ){\
+            platon::execute_action( rlp, &OP::elem );\
+        } 
+
+    // Helper macro for PLATON_DISPATCH
+    #define PLATON_DISPATCH_HELPER( TYPE,  MEMBERS ) \
+        BOOST_PP_SEQ_FOR_EACH( PLATON_DISPATCH_INTERNAL, TYPE, MEMBERS )
+
+    /**
+     * @addtogroup dispatcher
+     * Convenient macro to create contract apply handler
+     *
+     * @note To be able to use this macro, the contract needs to be derived from platon::contract
+     * @param TYPE - The class name of the contract
+     * @param MEMBERS - The sequence of available actions supported by this contract
+     *
+     * Example:
+     * @code
+     * PLATON_DISPATCH( hello, (init)(set_message)(change_message)(delete_message)(get_message) )
+     * @endcode
+     */
+    #define PLATON_DISPATCH( TYPE, MEMBERS ) \
+    extern "C" { \
+        void invoke(void) {  \
+            std::string method; \
+            auto input = get_input(); \
+            RLP rlp(input); \
+            fetch(rlp[0], method);\
+            if (method.empty()) {\
+                platon_assert(false, "valid method\n");\
+            }\
+            PLATON_DISPATCH_HELPER( TYPE, MEMBERS ) \
+            else {\
+                platon_assert(false, "no method to call\n");\
+            }\
+        } \
+    }\
+
+}

--- a/libraries/platonlib/include/platon/exception.h
+++ b/libraries/platonlib/include/platon/exception.h
@@ -17,7 +17,7 @@ namespace platon {
      */
     template<typename Arg, typename... Args>
     void platonThrow(Arg&& a, Args&&... args){
-        println(a, args...);
-        abort();
+  /*      println(a, args...);
+        abort();*/
     }
 }

--- a/libraries/platonlib/include/platon/exception.h
+++ b/libraries/platonlib/include/platon/exception.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include <stdlib.h>
-#include "print.hpp"
 
 namespace platon {
     /**

--- a/libraries/platonlib/include/platon/platon.hpp
+++ b/libraries/platonlib/include/platon/platon.hpp
@@ -15,5 +15,6 @@
 #include "platon/storagetype.hpp"
 #include "platon/deployedcontract.hpp"
 #include "platon/name.hpp"
+#include "platon/dispatcher.hpp"
 
 #define CONSTANT [[platon::constant]]

--- a/libraries/platonlib/include/platon/rlp_extend.hpp
+++ b/libraries/platonlib/include/platon/rlp_extend.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include<platon/RLP.h>
+
+namespace platon{
+
+/**
+ *  Deserialize a tuple
+ *
+ *  @brief Deserialize a tuple
+ *  @param ds - The stream to read
+ *  @param t - The destination for deserialized value
+ *  @tparam DataStream - Type of datastream
+ *  @tparam Args - Type of the objects contained in the tuple
+ *  @return DataStream& - Reference to the datastream
+ */
+template<typename... Args>
+void fetch(RLP rlp, std::tuple<Args...>& t ) {
+    int vect_index = 0;
+    boost::fusion::for_each( t, [&]( auto& i ) {
+        fetch(rlp[vect_index], i);
+        vect_index++;
+    });
+}
+
+}

--- a/libraries/platonlib/include/platon/rlp_serialize.hpp
+++ b/libraries/platonlib/include/platon/rlp_serialize.hpp
@@ -1,0 +1,63 @@
+#include <boost/preprocessor/seq/for_each.hpp>
+#include <boost/preprocessor/seq/enum.hpp>
+#include <boost/preprocessor/seq/size.hpp>
+#include <boost/preprocessor/seq/seq.hpp>
+#include <boost/preprocessor/stringize.hpp>
+#include "platon/RLP.h"
+#include "platon/common.h"
+#include<vector>
+
+#define PLATON_REFLECT_MEMBER_NUMBER( r, OP, elem ) \
+  items_number++;
+
+#define PLATON_REFLECT_MEMBER_OP_INPUT( r, OP, elem ) \
+  OP t.elem
+
+#define PLATON_REFLECT_MEMBER_OP_OUTPUT( r, OP, elem ) \
+  OP(rlp[vect_index], t.elem);\
+  vect_index++;
+
+/**
+ *  Defines serialization and deserialization for a class
+ *
+ *  @brief Defines serialization and deserialization for a class
+ *
+ *  @param TYPE - the class to have its serialization and deserialization defined
+ *  @param MEMBERS - a sequence of member names.  (field1)(field2)(field3)
+ */
+#define PLATON_SERIALIZE( TYPE,  MEMBERS ) \
+friend RLPStream& operator << ( RLPStream& rlp, const TYPE& t ){ \
+    size_t items_number = 0;\
+    BOOST_PP_SEQ_FOR_EACH( PLATON_REFLECT_MEMBER_NUMBER, <<, MEMBERS )\
+    return rlp.appendList(items_number) BOOST_PP_SEQ_FOR_EACH( PLATON_REFLECT_MEMBER_OP_INPUT, <<, MEMBERS );\
+}\
+friend void fetch(RLP rlp, TYPE& t){\
+    size_t vect_index = 0;\
+    BOOST_PP_SEQ_FOR_EACH( PLATON_REFLECT_MEMBER_OP_OUTPUT, fetch, MEMBERS )\
+}
+ 
+
+ /**
+ *  Defines serialization and deserialization for a class which inherits from other classes that
+ *  have their serialization and deserialization defined
+ *
+ *  @brief Defines serialization and deserialization for a class which inherits from other classes that
+ *  have their serialization and deserialization defined
+ *
+ *  @param TYPE - the class to have its serialization and deserialization defined
+ *  @param BASE - a sequence of base class names (basea)(baseb)(basec)
+ *  @param MEMBERS - a sequence of member names.  (field1)(field2)(field3)
+ */
+#define PLATON_SERIALIZE_DERIVED( TYPE, BASE, MEMBERS ) \
+friend RLPStream& operator << ( RLPStream& rlp, const TYPE& t ){ \
+    size_t items_number = 1;\
+    BOOST_PP_SEQ_FOR_EACH( PLATON_REFLECT_MEMBER_NUMBER, <<, MEMBERS )\
+    rlp.appendList(items_number) << static_cast<const BASE&>(t); \
+    return rlp BOOST_PP_SEQ_FOR_EACH( PLATON_REFLECT_MEMBER_OP_INPUT, <<, MEMBERS );\
+}\
+friend void fetch(RLP rlp, TYPE& t){\
+    size_t vect_index = 0;\
+    fetch(rlp[vect_index], static_cast<BASE&>(t));\
+    vect_index++;\
+    BOOST_PP_SEQ_FOR_EACH( PLATON_REFLECT_MEMBER_OP_OUTPUT, fetch, MEMBERS );\
+}

--- a/libraries/platonlib/include/platon/serialize.hpp
+++ b/libraries/platonlib/include/platon/serialize.hpp
@@ -4,7 +4,7 @@
 #include <boost/preprocessor/seq/seq.hpp>
 #include <boost/preprocessor/stringize.hpp>
 
-#define PLATON_REFLECT_MEMBER_OP( r, OP, elem ) \
+#define PLATON_REFLECT_MEMBER_OP_OLD( r, OP, elem ) \
   OP t.elem
 
 /**
@@ -28,14 +28,14 @@
  *  @param TYPE - the class to have its serialization and deserialization defined
  *  @param MEMBERS - a sequence of member names.  (field1)(field2)(field3)
  */
-#define PLATON_SERIALIZE( TYPE,  MEMBERS ) \
+#define PLATON_SERIALIZE_OLD( TYPE,  MEMBERS ) \
  template<typename DS> \
  friend DS& operator << ( DS& ds, const TYPE& t ){ \
-    return ds BOOST_PP_SEQ_FOR_EACH( PLATON_REFLECT_MEMBER_OP, <<, MEMBERS );\
+    return ds BOOST_PP_SEQ_FOR_EACH( PLATON_REFLECT_MEMBER_OP_OLD, <<, MEMBERS );\
  }\
  template<typename DS> \
  friend DS& operator >> ( DS& ds, TYPE& t ){ \
-    return ds BOOST_PP_SEQ_FOR_EACH( PLATON_REFLECT_MEMBER_OP, >>, MEMBERS );\
+    return ds BOOST_PP_SEQ_FOR_EACH( PLATON_REFLECT_MEMBER_OP_OLD, >>, MEMBERS );\
  }
 
 /**
@@ -49,15 +49,15 @@
  *  @param BASE - a sequence of base class names (basea)(baseb)(basec)
  *  @param MEMBERS - a sequence of member names.  (field1)(field2)(field3)
  */
-#define PLATON_SERIALIZE_DERIVED( TYPE, BASE, MEMBERS ) \
+#define PLATON_SERIALIZE_DERIVED_OLD( TYPE, BASE, MEMBERS ) \
  template<typename DS> \
  friend DS& operator << ( DS& ds, const TYPE& t ){ \
     ds << static_cast<const BASE&>(t); \
-    return ds BOOST_PP_SEQ_FOR_EACH( PLATON_REFLECT_MEMBER_OP, <<, MEMBERS );\
+    return ds BOOST_PP_SEQ_FOR_EACH( PLATON_REFLECT_MEMBER_OP_OLD, <<, MEMBERS );\
  }\
  template<typename DS> \
  friend DS& operator >> ( DS& ds, TYPE& t ){ \
     ds >> static_cast<BASE&>(t); \
-    return ds BOOST_PP_SEQ_FOR_EACH( PLATON_REFLECT_MEMBER_OP, >>, MEMBERS );\
+    return ds BOOST_PP_SEQ_FOR_EACH( PLATON_REFLECT_MEMBER_OP_OLD, >>, MEMBERS );\
  }
 ///@} serializecpp

--- a/libraries/platonlib/include/platon/service.hpp
+++ b/libraries/platonlib/include/platon/service.hpp
@@ -1,0 +1,56 @@
+#pragma once
+#include<vector>
+#include<string>
+#include "platon/common.h"
+#include "platon/RLP.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void platon_return(const void *res, const size_t len);
+size_t platon_input_length(void);
+void platon_get_input(const void *inputptr);
+void platon_panic( const char* cstr, const uint32_t len);
+
+#ifdef __cplusplus
+}
+#endif
+
+namespace platon {
+
+    template<typename T>
+    void platon_return(const T &t) {
+        RLPStream rlp_stream;
+        rlp_stream << t;
+        std::vector<byte> result = rlp_stream.out();
+        ::platon_return(result.data(), result.size()); 
+    } 
+
+    std::vector<byte> get_input(void) {
+        std::vector<byte> result;
+        size_t len = ::platon_input_length();
+        result.resize(len);
+        ::platon_get_input(result.data());
+        return result;
+    }
+
+    inline void platon_assert(bool pred, const char* msg) {
+      if (!pred) {
+		 ::platon_panic(msg, strlen(msg));
+      }
+   }
+
+   inline void platon_assert(bool pred, const std::string& msg) {
+      if (!pred) {
+		 ::platon_panic((char *)msg.c_str(), msg.size());
+      }
+   }
+
+   inline void platon_assert(bool pred, std::string&& msg) {
+      if (!pred) {
+		 ::platon_panic((char *)msg.c_str(), msg.size());
+      }
+   }
+
+}

--- a/libraries/platonlib/include/platon/storagetype.hpp
+++ b/libraries/platonlib/include/platon/storagetype.hpp
@@ -101,6 +101,7 @@ namespace platon {
         operator bool() const { return t_ ? true : false; }
 
         T get() const { return t_; }
+        T& self() { return t_; }
     private:
         /**
          * @brief Load from blockchain

--- a/libraries/platonlib/src/RLP.cpp
+++ b/libraries/platonlib/src/RLP.cpp
@@ -1,28 +1,10 @@
-/*
-	This file is part of cpp-ethereum.
-
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
-
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
-
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
-*/
-
-/*
 #include "platon/RLP.h"
+using namespace std;
 
 namespace platon {
+
 bytes RLPNull = rlp("");
 bytes RLPEmptyList = rlpList();
-
-
 
 RLP::RLP(bytesConstRef _d, Strictness _s):
         m_data(_d)
@@ -331,7 +313,6 @@ void RLPStream::pushCount(size_t _count, byte _base)
     pushInt(_count, br);
 }
 }
-*/
 
 //static void streamOut(std::ostream& _out, dev::RLP const& _d, unsigned _depth = 0)
 //{

--- a/libraries/platonlib/test/dispatcher_test.cpp
+++ b/libraries/platonlib/test/dispatcher_test.cpp
@@ -1,0 +1,84 @@
+#include "platon/dispatcher.hpp"
+#include "platon/common.h"
+#include <string>
+#include <iostream>
+#include <vector>
+
+using namespace platon;
+std::vector<byte> result;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void platon_return(const void *res, const size_t len){
+    byte *ptr = (byte *)res;
+    std::vector<byte> my_return;
+    for(size_t i = 0; i < len; i++) {
+        my_return.push_back(*ptr);
+        ptr++;
+    }
+    std::string str_return;
+    fetch(RLP(my_return), str_return);
+    std::cout << str_return << std::endl;
+}
+
+size_t platon_input_length(void){
+    return result.size();
+}
+
+void platon_get_input(const void *inputptr){
+    byte *ptr = (byte *)inputptr;
+    for (auto one :result) {
+        *ptr = one;
+        ptr++;
+    }
+}
+void platon_panic( const char* cstr, const uint32_t len){
+    for (uint32_t i = 0; i < len; i++) {
+        std::cout << *cstr;
+        cstr++;
+    }
+    std::cout << std::endl;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+
+class hello {
+    public:
+        hello(){m_info["jatel"] = "jatel_info";}
+        void init(){}
+
+        int set_message(const std::string &name, const std::string &one_message){
+            m_info[name] = one_message;
+            return 0;
+        }
+
+        int change_message(const std::string &name, const std::string  &one_message){
+            m_info[name] = one_message;
+            return 0;
+        }
+
+        int delete_message(const std::string &name){
+            m_info.erase(name);
+            return 0;
+        }
+
+        std::string get_message(const std::string &name){
+            return m_info[name];
+        }
+    private:
+        std::map<std::string, std::string> m_info; 
+};
+
+PLATON_DISPATCH(hello, (init)(set_message)(change_message)(delete_message)(get_message))
+
+int main(int argc, char **argv) {
+    RLPStream wht_stream;
+    wht_stream.appendList(2) << "get_message" << "jatel";
+    result = wht_stream.out();
+    invoke();
+}

--- a/libraries/platonlib/test/rlp_test.cpp
+++ b/libraries/platonlib/test/rlp_test.cpp
@@ -1,0 +1,139 @@
+#include "platon/RLP.h"
+#include "platon/rlp_serialize.hpp"
+#include <string>
+#include <iostream>
+#include <vector>
+#include <algorithm>
+
+using namespace platon;
+
+class WhtType 
+{
+    public:
+        WhtType(){}
+        WhtType(std::string name, uint16_t age, uint16_t weight): m_name(name), m_age(age), m_weight(weight) {}
+        friend RLPStream& operator << ( RLPStream& rlp, const WhtType& one ){
+            return rlp.appendList(3) << one.m_name << one.m_age << one.m_weight;
+        }
+        friend void fetch(RLP rlp, WhtType& one){
+            fetch(rlp[0], one.m_name);
+            fetch(rlp[1], one.m_age);
+            fetch(rlp[2], one.m_weight);
+        }
+        friend std::ostream &operator<<( std::ostream &output, const WhtType &one){
+            return output << one.m_name << ' ' << one.m_age << ' ' << one.m_weight;
+        }
+    private:
+	    std::string m_name;
+	    uint16_t m_age;  
+	    uint16_t m_weight;
+};
+
+class WhtGroup
+{
+    public:
+        WhtGroup(){}
+        WhtGroup(std::string info, uint16_t number,WhtType member): m_info(info), m_number(number), m_member(member) {}
+        friend RLPStream& operator << ( RLPStream& rlp, const WhtGroup& group ){
+            return rlp.appendList(3) << group.m_info << group.m_number << group.m_member;
+        }
+        friend void fetch(RLP rlp, WhtGroup& group){
+            fetch(rlp[0], group.m_info);
+            fetch(rlp[1], group.m_number);
+            fetch(rlp[2], group.m_member);
+        }
+        friend std::ostream &operator<<( std::ostream &output, const WhtGroup &group){
+            return output << group.m_info << ' ' << group.m_number << ' ' << group.m_member;
+        }
+    private:
+	    std::string m_info;
+	    uint16_t m_number;
+	    WhtType m_member;
+};
+
+class parent 
+{   
+    public:
+        parent(){}
+        parent(std::string info, uint16_t number, WhtType member): m_info(info), m_number(number), m_member(member) {}
+        PLATON_SERIALIZE(parent, (m_info)(m_number)(m_member))
+        friend std::ostream &operator<<( std::ostream &output, const parent &group){
+            return output << group.m_info << ' ' << group.m_number << ' ' << group.m_member;
+        }
+    private:
+	    std::string m_info;
+	    uint16_t m_number;
+	    WhtType m_member;
+};
+
+class derived : public parent 
+{
+    public:
+        derived(){}
+        derived(std::string info, uint16_t number, WhtType member, std::string other): parent(info, number, member), m_other(other){}
+        PLATON_SERIALIZE_DERIVED(derived, parent, (m_other))
+        friend std::ostream &operator<<( std::ostream &output, const derived &group){
+            return output << static_cast<const parent&>(group) << ' ' << group.m_other;
+        }
+    private:
+	    std::string m_other;  
+};
+
+int main(int argc, char **argv) {
+    // 定义字节输出函数
+    auto print = [](const byte& n) { std::cout << int(n) << ' '; };
+
+    // 定义变量
+    WhtType one("jatel", 30, 160);
+    WhtGroup group("group", 3, one);
+    RLPStream wht_stream;
+
+    // 测试 WhtType
+    wht_stream << one;
+    std::vector<byte> result = wht_stream.out();
+    std::for_each(result.begin(), result.end(), print);
+    std::cout <<  std::endl;
+
+    WhtType two;
+    fetch(RLP(result), two);
+    std::cout << two;
+    std::cout <<  std::endl;
+
+    // 测试 WhtGroup
+    wht_stream.clear();
+    wht_stream << group;
+    result = wht_stream.out();
+    std::for_each(result.begin(), result.end(), print);
+    std::cout <<  std::endl;
+
+    WhtGroup one_group;
+    fetch(RLP(result), one_group);
+    std::cout << one_group;
+    std::cout <<  std::endl;
+
+    // 测试 parent
+    parent test_parent("group", 3, one);
+    wht_stream.clear();
+    wht_stream << test_parent;
+    result = wht_stream.out();
+    std::for_each(result.begin(), result.end(), print);
+    std::cout <<  std::endl;
+
+    parent one_test_parent;
+    fetch(RLP(result), one_test_parent);
+    std::cout << one_test_parent;
+    std::cout <<  std::endl;
+
+    // 测试 derived
+    derived test_derived("group", 3, one, "jatel_derived");
+    wht_stream.clear();
+    wht_stream << test_derived;
+    result = wht_stream.out();
+    std::for_each(result.begin(), result.end(), print);
+    std::cout <<  std::endl;
+
+    derived one_test_derived;
+    fetch(RLP(result), one_test_derived);
+    std::cout << one_test_derived;
+    std::cout <<  std::endl;
+}

--- a/libraries/platonlib/test/storage_test.cpp
+++ b/libraries/platonlib/test/storage_test.cpp
@@ -46,6 +46,8 @@ void getState(const uint8_t* key, size_t klen, uint8_t *value, size_t vlen){
 }
 #endif
 
+extern char const contract_info[] = "info";
+
 class testContract 
 {
     public:
@@ -60,7 +62,7 @@ class testContract
         }
 
     private:
-        StorageType<1, std::vector<std::string>> info;
+        StorageType<contract_info, std::vector<std::string>> info;
 };
 
 int main(int argc, char **argv) {

--- a/libraries/platonlib/test/storage_test.cpp
+++ b/libraries/platonlib/test/storage_test.cpp
@@ -1,0 +1,92 @@
+#include "platon/storagetype.hpp"
+#include <iostream>
+#include <string>
+#include <vector>
+
+using namespace platon;
+std::map<std::vector<byte>, std::vector<byte> > result;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+std::vector<byte> getVector(const uint8_t* address, size_t len){
+    byte *ptr = (byte *)address;
+    std::vector<byte> vect_result;
+    for(size_t i = 0; i < len; i++) {
+        vect_result.push_back(*ptr);
+        ptr++;
+    }
+    return vect_result;
+}
+
+void setState(const uint8_t* key, size_t klen, const uint8_t *value, size_t vlen){
+    std::vector<byte> vect_key, vect_value;
+    vect_key = getVector(key, klen);
+    vect_value = getVector(value, vlen);
+    result[vect_key] = vect_value;
+}
+
+size_t getStateSize(const uint8_t* key, size_t klen){
+    std::vector<byte> vect_key;
+    vect_key = getVector(key, klen);
+    return result[vect_key].size();
+}
+
+void getState(const uint8_t* key, size_t klen, uint8_t *value, size_t vlen){
+    std::vector<byte> vect_key, vect_value;
+    vect_key = getVector(key, klen);
+    vect_value = result[vect_key];
+    for(size_t i = 0; i < vlen && i < vect_value.size(); i++){
+        *(value + i) = vect_value[i];
+    }
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+class testContract 
+{
+    public:
+        testContract(){}
+
+        void add_message(const std::string &one_message){
+            info.self().push_back(one_message);
+        }
+
+        std::vector<std::string> get_message(){
+            return info.self();
+        }
+
+    private:
+        StorageType<1, std::vector<std::string>> info;
+};
+
+int main(int argc, char **argv) {
+
+    {
+        testContract test1;
+        test1.add_message("test1");
+    }
+    
+    {
+        testContract test2;
+        test2.add_message("test2");
+        auto result = test2.get_message();
+        for (auto one : result){
+            std::cout << one;
+        }
+        std::cout << std::endl;
+    }
+
+    {
+        testContract test3;
+        test3.add_message("test3");
+        auto result = test3.get_message();
+        for (auto one : result){
+            std::cout << one;
+        }
+        std::cout << std::endl;
+    }
+}


### PR DESCRIPTION
1. Added contract related macros ACTION and CONST and CONTRACT.
2. Add RLP encoding to implement the macros PLATON_SERIALIZE and PLATON_SERIALIZE_DERIVED.
3. Adds the uniform entry function macro PLATON DISPATCH.
4. Change the storage implementation to RLP.
5. Add storage, RLP, unified access to related test files.