### PR TITLE
RLP extensions and fetch function parameter types change

### DIFF
--- a/libraries/platonlib/include/platon/RLP.h
+++ b/libraries/platonlib/include/platon/RLP.h
@@ -412,6 +412,18 @@ public:
     /// Shift operators for appending data items.
     template <class T> RLPStream& operator<<(T _data) { return append(_data); }
 
+    template <class _T>RLPStream& operator << (std::vector<_T> const& _s);
+
+    template <class _T, size_t S> RLPStream& operator << (std::array<_T, S> const& _s);
+
+    template <class _T> RLPStream& operator << (std::set<_T> const& _s);
+
+    template <class _T> RLPStream& operator << (std::unordered_set<_T> const& _s);
+
+    template <class T, class U> RLPStream& operator << (std::pair<T, U> const& _s);
+
+    template <class T, class U> RLPStream& operator << (std::map<T, U> const& _s);
+
     /// Clear the output stream so far.
     void clear() { m_out.clear(); m_listStack.clear(); }
 
@@ -473,9 +485,4 @@ template <class ... _Ts> bytes rlpList(_Ts ... _ts)
 /// Human readable version of RLP.
 //std::ostream& operator<<(std::ostream& _out, dev::RLP const& _d);
 
-}
-
-//get data from the RLP instance
-template <class T> void fetch(platon::RLP rlp, T &value){
-    value = T(rlp);
 }

--- a/libraries/platonlib/include/platon/dispatcher.hpp
+++ b/libraries/platonlib/include/platon/dispatcher.hpp
@@ -13,7 +13,8 @@
 #include <platon/service.hpp>
 #include <type_traits>
 #include <tuple>
-#include<platon/RLP.h>
+#include "platon/RLP.h"
+#include "platon/rlp_extend.hpp"
 
 namespace platon {
 

--- a/libraries/platonlib/include/platon/platon.hpp
+++ b/libraries/platonlib/include/platon/platon.hpp
@@ -1,20 +1,16 @@
 #pragma once
 #include "platon/contract.hpp"
-#include "platon/print.hpp"
-#include "platon/print.h"
 #include "platon/common.h"
 #include "platon/exception.h"
 #include "platon/fixedhash.hpp"
 #include "platon/state.hpp"
-#include "platon/event.hpp"
 #include "platon/storage.hpp"
 #include "platon/assert.h"
-#include "platon/db/array.hpp"
-#include "platon/db/list.hpp"
-#include "platon/db/map.hpp"
 #include "platon/storagetype.hpp"
-#include "platon/deployedcontract.hpp"
 #include "platon/name.hpp"
 #include "platon/dispatcher.hpp"
+#include "platon/RLP.h"
+#include "platon/rlp_extend.hpp"
+#include "platon/rlp_serialize.hpp"
 
 #define CONSTANT [[platon::constant]]

--- a/libraries/platonlib/include/platon/rlp_extend.hpp
+++ b/libraries/platonlib/include/platon/rlp_extend.hpp
@@ -1,21 +1,156 @@
 #pragma once
-
+#include "boost/fusion/algorithm/iteration/for_each.hpp"
 #include<platon/RLP.h>
 
 namespace platon{
 
-/**
- *  Deserialize a tuple
- *
- *  @brief Deserialize a tuple
- *  @param ds - The stream to read
- *  @param t - The destination for deserialized value
- *  @tparam DataStream - Type of datastream
- *  @tparam Args - Type of the objects contained in the tuple
- *  @return DataStream& - Reference to the datastream
- */
+template <class _T>
+RLPStream& RLPStream::operator << (std::vector<_T> const& _s){
+    appendList(_s.size());
+    for (auto const& i: _s) {
+        *this << i;
+    }
+    return *this;
+}
+
+template <class _T, size_t S> 
+RLPStream& RLPStream::operator << (std::array<_T, S> const& _s) { 
+    appendList(_s.size()); 
+    for (auto const& i: _s) {
+        *this << i;
+    }
+    return *this;
+}
+
+template <class _T> 
+RLPStream& RLPStream::operator << (std::set<_T> const& _s) { 
+    appendList(_s.size()); 
+    for (auto const& i: _s) {
+        *this << i;
+    }
+    return *this;
+}
+
+
+template <class _T> 
+RLPStream& RLPStream::operator << (std::unordered_set<_T> const& _s) { 
+    appendList(_s.size()); 
+    for (auto const& i: _s) {
+        *this << i;
+    }
+    return *this; 
+}
+
+template <class T, class U> 
+RLPStream& RLPStream::operator << (std::pair<T, U> const& _s) { 
+    appendList(2); 
+    *this << _s.first; 
+    *this << _s.second; 
+    return *this; 
+}
+
+template <class T, class U> 
+RLPStream& RLPStream::operator << (std::map<T, U> const& _s) { 
+    appendList(_s.size()); 
+    for (auto const& i: _s) {
+        *this << i;
+    }
+    return *this; 
+}
+
+//get data from the RLP instance
+template <class T> 
+void fetch(const RLP &rlp, T &value){
+    value = T(rlp);
+}
+
+template <class T>
+void fetch(const RLP &rlp, std::vector<T> &ret)
+{
+    if (rlp.isList()){
+        ret.reserve(rlp.itemCount());
+        for (auto const& i: rlp){
+            T one;
+            fetch(i, one);
+            ret.push_back(one);
+        }
+    }else{
+        platonThrow("bad cast");
+    }
+}
+
+
+template <class T>
+void fetch(const RLP &rlp, std::set<T> &ret)
+{
+    if (rlp.isList()){
+        for (auto const& i: rlp){
+            T one;
+            fetch(i, one);
+            ret.insert(one);
+        }
+    }else{
+        platonThrow("bad cast");
+    }
+}
+
+template <class T>
+void fetch(const RLP &rlp, std::unordered_set<T> &ret)
+{
+    if (rlp.isList()){
+        for (auto const& i: rlp){
+            T one;
+            fetch(i, one);
+            ret.insert(one);
+        }
+    }else{
+        platonThrow("bad cast");
+    }
+}
+
+template <class T, class U>
+void fetch(const RLP &rlp, std::pair<T, U> &ret)
+{
+    if (rlp.itemCountStrict() != 2){
+        platonThrow("bad cast");
+    }
+    T one;
+    fetch(rlp[0], one);
+    ret.first = one;
+    U two;
+    fetch(rlp[1], two);
+    ret.second = two;
+}
+
+template <class T, size_t N>
+void fetch(const RLP &rlp, std::array<T, N> &ret)
+{
+    if (rlp.itemCountStrict() != N){
+        platonThrow("bad cast");
+    }
+    for (size_t i = 0; i < N; ++i){
+        T one;
+        fetch(rlp[i], one);
+        ret[i] = one;
+    }
+}
+
+template <class T, class U>
+void fetch(const RLP &rlp, std::map<T, U> &ret)
+{
+    if (rlp.isList()){
+        for (auto const& i: rlp){
+            std::pair<T, U> one;
+            fetch(i, one);
+            ret.insert(one);
+        }
+    }else{
+        platonThrow("bad cast");
+    }
+}
+
 template<typename... Args>
-void fetch(RLP rlp, std::tuple<Args...>& t ) {
+void fetch(const RLP &rlp, std::tuple<Args...>& t ) {
     int vect_index = 0;
     boost::fusion::for_each( t, [&]( auto& i ) {
         fetch(rlp[vect_index], i);

--- a/libraries/platonlib/include/platon/rlp_serialize.hpp
+++ b/libraries/platonlib/include/platon/rlp_serialize.hpp
@@ -4,8 +4,9 @@
 #include <boost/preprocessor/seq/seq.hpp>
 #include <boost/preprocessor/stringize.hpp>
 #include "platon/RLP.h"
+#include "platon/rlp_extend.hpp"
 #include "platon/common.h"
-#include<vector>
+#include <vector>
 
 #define PLATON_REFLECT_MEMBER_NUMBER( r, OP, elem ) \
   items_number++;
@@ -31,7 +32,7 @@ friend RLPStream& operator << ( RLPStream& rlp, const TYPE& t ){ \
     BOOST_PP_SEQ_FOR_EACH( PLATON_REFLECT_MEMBER_NUMBER, <<, MEMBERS )\
     return rlp.appendList(items_number) BOOST_PP_SEQ_FOR_EACH( PLATON_REFLECT_MEMBER_OP_INPUT, <<, MEMBERS );\
 }\
-friend void fetch(RLP rlp, TYPE& t){\
+friend void fetch(const RLP &rlp, TYPE& t){\
     size_t vect_index = 0;\
     BOOST_PP_SEQ_FOR_EACH( PLATON_REFLECT_MEMBER_OP_OUTPUT, fetch, MEMBERS )\
 }
@@ -55,7 +56,7 @@ friend RLPStream& operator << ( RLPStream& rlp, const TYPE& t ){ \
     rlp.appendList(items_number) << static_cast<const BASE&>(t); \
     return rlp BOOST_PP_SEQ_FOR_EACH( PLATON_REFLECT_MEMBER_OP_INPUT, <<, MEMBERS );\
 }\
-friend void fetch(RLP rlp, TYPE& t){\
+friend void fetch(const RLP &rlp, TYPE& t){\
     size_t vect_index = 0;\
     fetch(rlp[vect_index], static_cast<BASE&>(t));\
     vect_index++;\

--- a/libraries/platonlib/test/contract_test.cpp
+++ b/libraries/platonlib/test/contract_test.cpp
@@ -1,0 +1,146 @@
+#include <platon/platon.hpp>
+#include <iostream>
+#include <string>
+#include <map>
+
+using namespace platon;
+
+class message {
+   public:
+      message(){}
+      message(const std::string &p_head):head(p_head){}
+      friend std::ostream &operator<<( std::ostream &output, const message &one_message){
+        return output << one_message.head;
+      }
+   private:
+      std::string head;
+      PLATON_SERIALIZE(message, (head))
+};
+
+class my_message : public message {
+   public:
+      my_message(){}
+      my_message(const std::string &p_head, const std::string &p_body, const std::string &p_end):message(p_head), body(p_body), end(p_end){}
+      friend std::ostream &operator<<( std::ostream &output, const my_message &group){
+        return output << static_cast<const message&>(group) << ' ' << group.body << ' ' << group.end;
+      }
+   private:
+      std::string body;
+      std::string end;
+      PLATON_SERIALIZE_DERIVED(my_message, message, (body)(end))
+};
+
+extern char const contract_info[] = "info";
+
+CONTRACT hello : public platon::Contract{
+   public:
+      ACTION void init(){}
+      ACTION std::vector<my_message> add_message(const my_message &one_message){
+          info.self().push_back(one_message);
+          return info.self();
+      }
+      CONST std::vector<my_message> get_message(const std::string &name){
+          std::cout << name << std::endl;
+          return info.self();
+      }
+   private:
+      platon::StorageType<contract_info, std::vector<my_message>> info;
+};
+
+PLATON_DISPATCH(hello, (init)(add_message)(get_message))
+
+std::vector<byte> input_result;
+std::map<std::vector<byte>, std::vector<byte> > map_result;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void platon_return(const void *res, const size_t len){
+    byte *ptr = (byte *)res;
+    std::vector<byte> my_return;
+    for(size_t i = 0; i < len; i++) {
+        my_return.push_back(*ptr);
+        ptr++;
+    }
+    std::vector<my_message> info_return;
+    fetch(RLP(my_return), info_return);
+    for (auto const& i: info_return){
+        std::cout << i << ' ';
+    }
+    std::cout << std::endl;
+}
+
+size_t platon_input_length(void){
+    return input_result.size();
+}
+
+void platon_get_input(const void *inputptr){
+    byte *ptr = (byte *)inputptr;
+    for (auto one :input_result) {
+        *ptr = one;
+        ptr++;
+    }
+}
+
+void platon_panic( const char* cstr, const uint32_t len){
+    for (uint32_t i = 0; i < len; i++) {
+        std::cout << *cstr;
+        cstr++;
+    }
+    std::cout << std::endl;
+}
+
+std::vector<byte> getVector(const uint8_t* address, size_t len){
+    byte *ptr = (byte *)address;
+    std::vector<byte> vect_result;
+    for(size_t i = 0; i < len; i++) {
+        vect_result.push_back(*ptr);
+        ptr++;
+    }
+    return vect_result;
+}
+
+void setState(const uint8_t* key, size_t klen, const uint8_t *value, size_t vlen){
+    std::vector<byte> vect_key, vect_value;
+    vect_key = getVector(key, klen);
+    vect_value = getVector(value, vlen);
+    map_result[vect_key] = vect_value;
+}
+
+size_t getStateSize(const uint8_t* key, size_t klen){
+    std::vector<byte> vect_key;
+    vect_key = getVector(key, klen);
+    return map_result[vect_key].size();
+}
+
+void getState(const uint8_t* key, size_t klen, uint8_t *value, size_t vlen){
+    std::vector<byte> vect_key, vect_value;
+    vect_key = getVector(key, klen);
+    vect_value = map_result[vect_key];
+    for(size_t i = 0; i < vlen && i < vect_value.size(); i++){
+        *(value + i) = vect_value[i];
+    }
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+
+int main(int argc, char **argv) {
+    RLPStream wht_stream;
+    my_message one("1_head", "1_body", "1_end");
+    wht_stream.appendList(2) << "add_message" << one;
+    input_result = wht_stream.out();
+    invoke();
+    wht_stream.clear();
+    my_message two("2_head", "2_body", "2_end");
+    wht_stream.appendList(2) << "add_message" << two;
+    input_result = wht_stream.out();
+    invoke();
+    wht_stream.clear();
+    wht_stream.appendList(2) << "get_message" << "jatel";
+    input_result = wht_stream.out();
+    invoke();
+}

--- a/libraries/platonlib/test/dispatcher_test.cpp
+++ b/libraries/platonlib/test/dispatcher_test.cpp
@@ -1,5 +1,4 @@
-#include "platon/dispatcher.hpp"
-#include "platon/common.h"
+#include "platon/platon.hpp"
 #include <string>
 #include <iostream>
 #include <vector>

--- a/libraries/platonlib/test/rlp_test.cpp
+++ b/libraries/platonlib/test/rlp_test.cpp
@@ -1,9 +1,11 @@
 #include "platon/RLP.h"
+#include "platon/rlp_extend.hpp"
 #include "platon/rlp_serialize.hpp"
 #include <string>
 #include <iostream>
 #include <vector>
 #include <algorithm>
+# include <map>
 
 using namespace platon;
 
@@ -135,5 +137,20 @@ int main(int argc, char **argv) {
     derived one_test_derived;
     fetch(RLP(result), one_test_derived);
     std::cout << one_test_derived;
+    std::cout <<  std::endl;
+
+    // 测试 std::map
+    std::map<std::string, derived> map_test;
+    map_test["wht_1"] = test_derived;
+    map_test["wht_2"] = derived("group_map", 3, one, "jatel_derived_map");
+    wht_stream.clear();
+    wht_stream << map_test;
+    result = wht_stream.out();
+
+    std::map<std::string, derived> map_test_one;
+    fetch(RLP(result), map_test_one);
+    for( auto i : map_test_one) {
+        std::cout << i.first << ' ' << i.second << ' ';
+    }
     std::cout <<  std::endl;
 }

--- a/libraries/platonlib/test/storage_test.cpp
+++ b/libraries/platonlib/test/storage_test.cpp
@@ -1,4 +1,5 @@
 #include "platon/storagetype.hpp"
+#include "platon/rlp_extend.hpp"
 #include <iostream>
 #include <string>
 #include <vector>


### PR DESCRIPTION
1. Add RLP coding for STL containers
2. Change the parameter type of the fetch function to the regular drinking type
3. Added RLP extensions and contract unit testing