### PR TITLE
Add Energon type and operator

### DIFF
--- a/libraries/platonlib/include/platon/authority.hpp
+++ b/libraries/platonlib/include/platon/authority.hpp
@@ -20,6 +20,11 @@ static const size_t address_len = 20;
 static const char sys_whitelist_name[] = "$platon$whitelist";
 static const char sys_owner_name[] = "$platon$owner";
 
+/**
+ * @brief Get the address of the transaction initiator
+ *
+ * @return The address of the transaction initiator
+ */
 Address platon_caller() {
   bytes address_bytes;
   address_bytes.resize(address_len);
@@ -27,6 +32,11 @@ Address platon_caller() {
   return Address(address_bytes);
 }
 
+/**
+ * @brief Get the address of the original transaction initiator
+ *
+ * @return The address of the original transaction initiator
+ */
 Address platon_origin_caller() {
   bytes address_bytes;
   address_bytes.resize(address_len);
@@ -34,6 +44,11 @@ Address platon_origin_caller() {
   return Address(address_bytes);
 }
 
+/**
+ * @brief Get the address of contract
+ *
+ * @return The address of contract
+ */
 Address platon_contract_address() {
   bytes address_bytes;
   address_bytes.resize(address_len);
@@ -41,6 +56,12 @@ Address platon_contract_address() {
   return Address(address_bytes);
 }
 
+/**
+ * @brief Set the address as contracts owner
+ *
+ * @param address Accounts address, if address empty that
+ *                set caller as contract owner
+ */
 void set_owner(const std::string &address = std::string()) {
   Address platon_addr(address);
   if (address.empty()) {
@@ -51,11 +72,23 @@ void set_owner(const std::string &address = std::string()) {
   owner_addr.self() = platon_addr;
 }
 
+/**
+ * @brief Get the owner of contact
+ *
+ * @return The address of contract
+ */
 Address owner() {
   StorageType<sys_owner_name, Address> owner_addr;
   return owner_addr.self();
 }
 
+/**
+ * @brief Whether the input address is owner of contract
+ *
+ * @param addr Accounts address, if `addr` empty that set
+ *             `addr` to origin caller
+ * @return true if the input address is owner, false otherwise
+ */
 bool is_owner(const std::string &addr = std::string()) {
   Address platon_addr(addr);
   if (addr.empty()) {
@@ -66,18 +99,61 @@ bool is_owner(const std::string &addr = std::string()) {
   return owner_addr.self() == platon_addr;
 }
 
+/**
+ * @brief Persist storage whitelist implement
+ *
+ * @tparam Name Whitelist name, in the same contract, the name should be unique
+ */
 template <const char *Name>
 class WhiteList {
  public:
+  /**
+   * @brief Construct a new whitlist.
+   */
   WhiteList() : whitelist_() {}
 
+  /**
+   * @brief Add the address to whitelist
+   *
+   * @param addr Accounts address
+   */
   void Add(const std::string &addr) { Add(Address(addr)); }
+
+  /**
+   * @brief Add the address to whitelist
+   *
+   * @param addr Accounts address
+   */
   void Add(const Address &addr) { whitelist_.self().insert(addr); }
 
+  /**
+   * @brief Delete the address from whitelist
+   *
+   * @param addr Accounts address
+   */
   void Delete(const std::string &addr) { Delete(Address(addr)); }
+
+  /**
+   * @brief Delete the address from whitelist
+   *
+   * @param addr Accounts address
+   */
   void Delete(const Address &addr) { whitelist_.self().erase(addr); }
 
+  /**
+   * @brief Whether the address exists in whitelist
+   *
+   * @param addr Accounts address
+   * @return true if exists, false otherwise
+   */
   bool Exists(const std::string &addr) { return Exists(Address(addr)); }
+
+  /**
+   * @brief Whether the address exists in whitelist
+   *
+   * @param addr Accounts address
+   * @return true if exists, false otherwise
+   */
   bool Exists(const Address &addr) {
     return whitelist_.self().find(addr) != whitelist_.self().end();
   }
@@ -86,6 +162,9 @@ class WhiteList {
   Set<Name, Address> whitelist_;
 };
 
+/**
+ * @brief System default whitelist
+ */
 using SysWhitelist = WhiteList<sys_whitelist_name>;
 
 }  // namespace platon

--- a/libraries/platonlib/include/platon/exchange.hpp
+++ b/libraries/platonlib/include/platon/exchange.hpp
@@ -11,13 +11,35 @@ namespace platon {
  * @brief The unit of Energon
  */
 enum EnergonUnit {
-  VonUnit = 1,
-  GVonUnit = 1000000000,
-  LATUnit = 1000000000000000000
+  VON = 1,
+  kVON = 1000,
+  mVON = 1000000,
+  gVON = 1000000000,
+  uLAT = 1000000000000,
+  mLAT = 1000000000000000,
+  LAT = 1000000000000000000
 };
 
 /**
  * @brief Energo is a type of currency
+ *
+ * Example:
+ *   void test() {
+ *     // New a Energon
+ *     Energon e(10);
+ *     u256 von = 10;
+ *     Energon o(u256);
+ *
+ *     // Gets value
+ *     u256 val = e.Get();
+ *
+ *     // Serialize to big-ending bytes
+ *     bytes bs = e.Bytes();
+ *
+ *     // Add amount of Energon
+ *     Energon sum = e.Add(0);
+ *     e += o;
+ *   }
  */
 class Energon {
  public:
@@ -94,33 +116,70 @@ class Energon {
 /**
  * string-literal operator
  *
- * @brief 1_Von representing one Von
- * @param von Amount of Von
+ * @brief 1_VON representing one VON
+ *
+ * @param von Amount of VON
  * @return Energon
+ *
+ * Energon e = 100_VON;
  */
-Energon operator""_Von(uint64_t von) { return Energon(von); }
+Energon operator""_VON(uint64_t von) { return Energon(von); }
 
 /**
  * string-literal operator
  *
- * @breif 1_GVon representing 1e9Von
- * @param gvon Amount of GVon
+ * @brief 1_kVON representing 1000 VON
+ *
+ * @param kvon Amount of kVON
  * @return Energon
+ *
+ * Energon e = 10_kVON;
  */
-Energon operator""_GVon(long double gvon) {
-  return Energon(gvon * u256(GVonUnit));
-}
+Energon operator""_kVON(uint64_t kvon) { return Energon(kvon * u256(kVON)); }
+
+/**
+ * @brief 1_mVON representing 1e3 VON
+ *
+ * @param mvon Amount of mVON
+ * @return Energon
+ *
+ * Energon e = 5_mVON;
+ */
+Energon operator""_mVON(uint64_t mvon) { return Energon(mvon * u256(mVON)); }
 
 /**
  * string-literal operator
  *
- * @breif 1_GVon representing 1e9Von
- * @param gvon Amount of GVon
+ * @brief 1_GVon representing 1e9 VON
+ *
+ * @param gvon Amount of gVON
  * @return Energon
+ *
+ * Energon e = 2.1111_gVON;
  */
-Energon operator""_GVon(uint64_t gvon) {
-  return Energon(gvon * u256(GVonUnit));
-}
+Energon operator""_gVON(uint64_t gvon) { return Energon(gvon * u256(gVON)); }
+
+/**
+ * string-literal operator
+ *
+ * @brief 1_uLAT representing 1e12 VON
+ * @param ulat Amount of uLAT
+ * @return Energon
+ *
+ * Energon e = 1_uLAT;
+ */
+Energon operator""_uLAT(uint64_t ulat) { return Energon(ulat * u256(uLAT)); }
+
+/**
+ * string-literal operator
+ *
+ * @brief 1_mLAT representing 1e15 VON
+ * @param mlat Amount of mLAT
+ * @return Energon
+ *
+ * Energon e = 6_mLAT;
+ */
+Energon operator""_mLAT(uint64_t mlat) { return Energon(mlat * u256(mLAT)); }
 
 /**
  * string-literal operator
@@ -128,27 +187,86 @@ Energon operator""_GVon(uint64_t gvon) {
  * @brief 1_LAT representing 1e18Von
  * @param lat Amount of LAT
  * @return Energon
+ *
+ * Energon e = 33_LAT;
  */
-Energon operator""_LAT(long double lat) { return Energon(lat * u256(LATUnit)); }
+Energon operator""_LAT(uint64_t lat) { return Energon(lat * u256(LAT)); }
 
 /**
- * string-literal operator
+ * @brief Compare two optional objects lhs and rhs is equal
  *
- * @brief 1_LAT representing 1e18Von
- * @param lat Amount of LAT
- * @return Energon
+ * @param lhs Amount of VON
+ * @param rhs Amount of VON
+ * @return true if lhs == rhs, false otherwise
+ *
+ * Energon lhs(10);
+ * Energon rhs(10);
+ * if (lhs == rhs) {}
  */
-Energon operator""_LAT(uint64_t lat) { return Energon(lat * u256(LATUnit)); }
+bool operator==(const Energon& lhs, const Energon& rhs) {
+  return lhs.Get() == rhs.Get();
+}
+
+/**
+ * @brief Compare two optional objects lhs and rhs
+ *
+ * @param lhs Amount of VON
+ * @param rhs Amount of VON
+ * @return true if lhs > rhs, false otherwise
+ *
+ * Energon lhs(12);
+ * Energon rhs(10);
+ * if (lhs > rhs) {}
+ */
+bool operator>(const Energon& lhs, const Energon& rhs) {
+  return lhs.Get() > rhs.Get();
+}
+
+/**
+ * @brief Compare two optional objects lhs and rhs
+ *
+ * @param lhs Amount of VON
+ * @param rhs Amount of VON
+ * @return true if lhs < rhs, false otherwise
+ *
+ * Energon lhs(122);
+ * Energon rhs(12222);
+ * if (lhs < rhs) {}
+ */
+bool operator<(const Energon& lhs, const Energon& rhs) {
+  return lhs.Get() < rhs.Get();
+}
 
 /**
  * @brief Implements the addition operators for Energon
  *
- * @param a Amount of Von
- * @param b Amount of Von
+ * @param a Amount of VON
+ * @param b Amount of VON
  * @return Energon
+ *
+ * Energon energon = 1_VON + 1_LAT;
  */
-Energon operator+(const Energon& a, const Energon& b) {
-  return Energon(0).Add(a).Add(b);
+Energon operator+(const Energon& lhs, const Energon& rhs) {
+  return Energon(0).Add(lhs).Add(rhs);
+}
+
+/**
+ * @brief Implements the subtraction operator for Energon
+ *
+ * @param a Amount of VON
+ * @param b Amount of VON
+ * @return Energon
+ *
+ * Energon e = 1_kVON - 10_VON;
+ * Energon e0(10);
+ * Energon e1(2);
+ * Energon ee = e0 - e1;
+ */
+Energon operator-(const Energon& lhs, const Energon& rhs) {
+  if (lhs < rhs) {
+    platon_throw("overflow");
+  }
+  return Energon(lhs.Get() - rhs.Get());
 }
 
 /**

--- a/libraries/platonlib/include/platon/exchange.hpp
+++ b/libraries/platonlib/include/platon/exchange.hpp
@@ -1,0 +1,166 @@
+#pragma once
+
+#include "bigint.hpp"
+#include "chain.hpp"
+#include "common.h"
+#include "fixedhash.hpp"
+
+namespace platon {
+
+/**
+ * @brief The unit of Energon
+ */
+enum EnergonUnit {
+  VonUnit = 1,
+  GVonUnit = 1000000000,
+  LATUnit = 1000000000000000000
+};
+
+/**
+ * @brief Energo is a type of currency
+ */
+class Energon {
+ public:
+  /**
+   * @brief Construct a new Energon
+   *
+   * @param n amount of Von
+   */
+  Energon(uint64_t n) : value_(n) {}
+
+  /**
+   * @brief Construct a new Energon
+   *
+   * @param n amount of Von
+   */
+  Energon(u256 n) : value_(n) {}
+
+  /**
+   * @brief Get amount of Von
+   *
+   * @return The amount of Von
+   */
+  const u256 Get() const { return value_; }
+
+  /**
+   * @brief Get the bytes of value, the bytes use big-end representations
+   *
+   * @return The bytes of value
+   */
+  const bytes Bytes() const {
+    bytes bs;
+    bs.resize(32);
+    toBigEndian(value_, bs);
+    return bs;
+  }
+
+  /**
+   * @brief Add amount of Von
+   *
+   * @param v Amount of Von
+   * @return The reference of Energon
+   */
+  Energon& Add(const u256& v) {
+    value_ += v;
+    return *this;
+  }
+
+  /**
+   * @brief Add amount of Von
+   *
+   * @param rhs Amount of Von
+   * @return The reference of Energon
+   */
+  Energon& Add(const Energon& rhs) {
+    this->value_ += rhs.value_;
+    return *this;
+  }
+
+  /**
+   * @brief Implement operator `+=`
+   *
+   * @param rhs Energon object
+   * @return The reference of Energon
+   */
+  Energon& operator+=(const Energon& rhs) {
+    this->value_ += rhs.value_;
+    return *this;
+  }
+
+ private:
+  u256 value_;
+};
+
+/**
+ * string-literal operator
+ *
+ * @brief 1_Von representing one Von
+ * @param von Amount of Von
+ * @return Energon
+ */
+Energon operator""_Von(uint64_t von) { return Energon(von); }
+
+/**
+ * string-literal operator
+ *
+ * @breif 1_GVon representing 1e9Von
+ * @param gvon Amount of GVon
+ * @return Energon
+ */
+Energon operator""_GVon(long double gvon) {
+  return Energon(gvon * u256(GVonUnit));
+}
+
+/**
+ * string-literal operator
+ *
+ * @breif 1_GVon representing 1e9Von
+ * @param gvon Amount of GVon
+ * @return Energon
+ */
+Energon operator""_GVon(uint64_t gvon) {
+  return Energon(gvon * u256(GVonUnit));
+}
+
+/**
+ * string-literal operator
+ *
+ * @brief 1_LAT representing 1e18Von
+ * @param lat Amount of LAT
+ * @return Energon
+ */
+Energon operator""_LAT(long double lat) { return Energon(lat * u256(LATUnit)); }
+
+/**
+ * string-literal operator
+ *
+ * @brief 1_LAT representing 1e18Von
+ * @param lat Amount of LAT
+ * @return Energon
+ */
+Energon operator""_LAT(uint64_t lat) { return Energon(lat * u256(LATUnit)); }
+
+/**
+ * @brief Implements the addition operators for Energon
+ *
+ * @param a Amount of Von
+ * @param b Amount of Von
+ * @return Energon
+ */
+Energon operator+(const Energon& a, const Energon& b) {
+  return Energon(0).Add(a).Add(b);
+}
+
+/**
+ * @brief Transfer the amount of Energon to address
+ *
+ * @param addr Accounts address
+ * @param amount The amount of Energon
+ * @return The call succeeds or fails
+ */
+int32_t platon_transfer(const Address& addr, const Energon& amount) {
+  auto bs = amount.Bytes();
+  return ::platon_transfer(addr.data(), bs.data(), bs.size());
+}
+
+}  // namespace platon

--- a/libraries/platonlib/include/platon/platon.hpp
+++ b/libraries/platonlib/include/platon/platon.hpp
@@ -15,3 +15,4 @@
 #include "platon/print.hpp"
 #include "platon/assert.hpp"
 #include "platon/chain.hpp"
+#include "platon/exchange.hpp"

--- a/tests/unit/exchange_test.cpp
+++ b/tests/unit/exchange_test.cpp
@@ -4,23 +4,38 @@
 using namespace platon;
 
 TEST_CASE(exchange, energon) {
-    Energon one_von = 1_Von;
-    ASSERT(one_von.Get() == u256(VonUnit));
+    Energon one_von = 1_VON;
+    ASSERT(one_von == Energon(VON));
 
-    Energon one_gvon = 1_GVon;
-    ASSERT(one_gvon.Get() == u256(GVonUnit));
+    Energon kvon = 1_kVON;
+    ASSERT(kvon == Energon(kVON));
+
+    Energon mvon = 1_mVON;
+    ASSERT(mvon == Energon(mVON));
+
+    Energon one_gvon = 1_gVON;
+    ASSERT(one_gvon.Get() == u256(gVON));
+
+    Energon ulat = 1_uLAT;
+    ASSERT(ulat == Energon(uLAT));
+
+    Energon mlat = 1_mLAT;
+    ASSERT(mlat == Energon(mLAT));
 
     Energon one_lat = 1_LAT;
-    ASSERT(one_lat.Get() == u256(LATUnit));
+    ASSERT(one_lat.Get() == u256(LAT));
 
-    one_lat += 1_Von;
-    ASSERT(one_lat.Get() == u256(LATUnit + VonUnit));
+    one_lat += 1_VON;
+    ASSERT(one_lat.Get() == u256(LAT + VON));
 
-    Energon gon = 1_Von + 1_LAT;
-    ASSERT(gon.Get() == u256(VonUnit+LATUnit));
+    Energon gon = 1_VON + 1_LAT;
+    ASSERT(gon.Get() == u256(VON+LAT));
 
-    ASSERT((1.5_LAT).Get() == u256(1.5*LATUnit));
-    ASSERT((0.0000000122_GVon).Get() == u256(0.0000000122*GVonUnit));
+    ASSERT(one_von < kvon);
+    ASSERT(mvon > kvon);
+    ASSERT(ulat > mvon);
+    ASSERT(mlat > ulat);
+    ASSERT(one_lat > mlat);
 }
 
 UNITTEST_MAIN() {

--- a/tests/unit/exchange_test.cpp
+++ b/tests/unit/exchange_test.cpp
@@ -1,0 +1,28 @@
+#include "platon/exchange.hpp"
+#include "unit_test.hpp"
+
+using namespace platon;
+
+TEST_CASE(exchange, energon) {
+    Energon one_von = 1_Von;
+    ASSERT(one_von.Get() == u256(VonUnit));
+
+    Energon one_gvon = 1_GVon;
+    ASSERT(one_gvon.Get() == u256(GVonUnit));
+
+    Energon one_lat = 1_LAT;
+    ASSERT(one_lat.Get() == u256(LATUnit));
+
+    one_lat += 1_Von;
+    ASSERT(one_lat.Get() == u256(LATUnit + VonUnit));
+
+    Energon gon = 1_Von + 1_LAT;
+    ASSERT(gon.Get() == u256(VonUnit+LATUnit));
+
+    ASSERT((1.5_LAT).Get() == u256(1.5*LATUnit));
+    ASSERT((0.0000000122_GVon).Get() == u256(0.0000000122*GVonUnit));
+}
+
+UNITTEST_MAIN() {
+    RUN_TEST(exchange, energon);
+}


### PR DESCRIPTION
`Energon` is a currency type for PlatON. 

`Energon` currency unit:
- `_VON`  representing 1 VON
``` Energon e = 10_VON; ```
- `_kVON`  representing 1e3 VON
`Energon e = 1_kVON;`
- `_mVON` representing 1e6 VON
`Energon e = 1_mVON;`
- `_gVON` representing 1e9 VON
`Energon e = 1_gVON;`
-  `_uLAT` representing 1e12 VON
`Energon e = 1_uLAT;`
- `_mLAT1` representing 1e15 VON
`Energon e = 1_mLAT;`
- `_LAT` representing 1e18
`Energon e = 1_LAT；`