### PR TITLE
RLP adds int type support

### DIFF
--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -11,6 +11,7 @@ set(INC_OUTPUT ${PLATON_CDT}/include)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-everything --target=wasm32 -nostdlib -fno-builtin -ffreestanding  -fno-threadsafe-statics  -Oz")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-everything --target=wasm32 -nostdlib -nostdinc -fno-builtin -ffreestanding  -fno-threadsafe-statics  -Oz  -fno-rtti -fno-exceptions -std=c++17")
 
+add_definitions("-DNDEBUG")
 add_subdirectory(libc)
 add_subdirectory(libc++)
 add_subdirectory(builtins)

--- a/libraries/platonlib/include/platon/RLP.h
+++ b/libraries/platonlib/include/platon/RLP.h
@@ -230,6 +230,7 @@ class RLP {
   explicit operator bigint() const { return toInt<bigint>(); }
   explicit operator int8_t() const { return toSignedInt<int8_t>(); }
   explicit operator int16_t() const { return toSignedInt<int16_t>(); }
+  explicit operator int() const { return toSignedInt<int>(); }
   explicit operator int32_t() const { return toSignedInt<int32_t>(); }
   explicit operator int64_t() const { return toSignedInt<int64_t>(); }
   explicit operator float() const { return toFloat(); }
@@ -547,6 +548,12 @@ struct Converter<int16_t> {
   }
 };
 template <>
+struct Converter<int> {
+  static int convert(RLP const& _r, int _flags) {
+    return _r.toSignedInt<int>(_flags);
+  }
+};
+template <>
 struct Converter<int32_t> {
   static int32_t convert(RLP const& _r, int _flags) {
     return _r.toSignedInt<int32_t>(_flags);
@@ -638,6 +645,7 @@ class RLPStream {
   RLPStream& append(bigint _i);
   RLPStream& append(int8_t _c) { return append(int64_t(_c)); }
   RLPStream& append(int16_t _s) { return append(int64_t(_s)); }
+  RLPStream& append(int _c) { return append(int64_t(_c)); }
   RLPStream& append(int32_t _s) { return append(int64_t(_s)); }
   RLPStream& append(int64_t _l) {
     uint64_t _i = uint64_t((_l << 1) ^ (_l >> 63));

--- a/tests/unit/rlp_test.cpp
+++ b/tests/unit/rlp_test.cpp
@@ -1,15 +1,167 @@
 #include "unit_test.hpp"
 #include "platon/RLP.h"
+#include "platon/rlp_extend.hpp"
+#include "platon/rlp_serialize.hpp"
 #include "platon/fixedhash.hpp"
+#include "platon/print.hpp"
 
 using namespace platon;
 
+TEST_CASE(rlp, int8_t) {
+  int8_t int8_t_data = -2; 
+  RLPStream stream;
+  stream << int8_t_data;
+  std::vector<byte> result = stream.out();
+  for(auto i : result){
+    platon::println(i);
+  }
+  int8_t_data = 0;
+  fetch(RLP(result), int8_t_data);
+  ASSERT_EQ(int8_t_data, -2, int8_t_data);
+}
+
+TEST_CASE(rlp, int16_t) {
+  int16_t int16_t_data = -3; 
+  RLPStream stream;
+  stream << int16_t_data;
+  std::vector<byte> result = stream.out();
+  for(auto i : result){
+    platon::println(i);
+  }
+  int16_t_data = 0;
+  fetch(RLP(result), int16_t_data);
+  ASSERT_EQ(int16_t_data, -3, int16_t_data);
+}
+
 TEST_CASE(rlp, int) {
-  std::string data = "c3010203";
-  RLPStream stream(3);
-  stream << 1 << 2 << 3;
-  std::string result = toHex(stream.out());
-  ASSERT_EQ(result, data, result, data);
+  int int_data = -4; 
+  RLPStream stream;
+  stream << int_data;
+  std::vector<byte> result = stream.out();
+  for(auto i : result){
+    platon::println(i);
+  }
+  int_data = 0;
+  fetch(RLP(result), int_data);
+  ASSERT_EQ(int_data, -4, int_data);
+}
+
+TEST_CASE(rlp, int32_t) {
+  int32_t int32_t_data = -5; 
+  RLPStream stream;
+  stream << int32_t_data;
+  std::vector<byte> result = stream.out();
+  for(auto i : result){
+    platon::println(i);
+  }
+  int32_t_data = 0;
+  fetch(RLP(result), int32_t_data);
+  ASSERT_EQ(int32_t_data, -5, int32_t_data);
+}
+
+TEST_CASE(rlp, int64_t) {
+  int64_t int64_t_data = -6; 
+  RLPStream stream;
+  stream << int64_t_data;
+  std::vector<byte> result = stream.out();
+  for(auto i : result){
+    platon::println(i);
+  }
+  int64_t_data = 0;
+  fetch(RLP(result), int64_t_data);
+  ASSERT_EQ(int64_t_data, -6, int64_t_data);
+}
+
+TEST_CASE(rlp, bool) {
+  bool bool_data = true; 
+  RLPStream stream;
+  stream << bool_data;
+  std::vector<byte> result = stream.out();
+  for(auto i : result){
+    platon::println(i);
+  }
+  bool_data = false;
+  fetch(RLP(result), bool_data);
+  ASSERT_EQ(bool_data, true, bool_data);
+}
+
+TEST_CASE(rlp, uint8_t) {
+  uint8_t uint8_t_data = 1; 
+  RLPStream stream;
+  stream << uint8_t_data;
+  std::vector<byte> result = stream.out();
+  for(auto i : result){
+    platon::println(i);
+  }
+  uint8_t_data = 0;
+  fetch(RLP(result), uint8_t_data);
+  ASSERT_EQ(uint8_t_data, 1, uint8_t_data);
+}
+
+TEST_CASE(rlp, uint16_t) {
+  uint16_t uint16_t_data = 2; 
+  RLPStream stream;
+  stream << uint16_t_data;
+  std::vector<byte> result = stream.out();
+  for(auto i : result){
+    platon::println(i);
+  }
+  uint16_t_data = 0;
+  fetch(RLP(result), uint16_t_data);
+  ASSERT_EQ(uint16_t_data, 2, uint16_t_data);
+}
+
+TEST_CASE(rlp, uint32_t) {
+  uint32_t uint32_t_data = 3; 
+  RLPStream stream;
+  stream << uint32_t_data;
+  std::vector<byte> result = stream.out();
+  for(auto i : result){
+    platon::println(i);
+  }
+  uint32_t_data = 0;
+  fetch(RLP(result), uint32_t_data);
+  ASSERT_EQ(uint32_t_data, 3, uint32_t_data);
+}
+
+TEST_CASE(rlp, uint64_t) {
+  uint64_t uint64_t_data = 4; 
+  RLPStream stream;
+  stream << uint64_t_data;
+  std::vector<byte> result = stream.out();
+  for(auto i : result){
+    platon::println(i);
+  }
+  uint64_t_data = 0;
+  fetch(RLP(result), uint64_t_data);
+  ASSERT_EQ(uint64_t_data, 4, uint64_t_data);
+}
+
+TEST_CASE(rlp, float) {
+  float float_data = 1.23; 
+  RLPStream stream;
+  stream << float_data;
+  std::vector<byte> result = stream.out();
+  for(auto i : result){
+    platon::println(i);
+  }
+  float_data = 0;
+  fetch(RLP(result), float_data);
+  platon::println(float_data);
+}
+
+
+TEST_CASE(rlp, double) {
+  double double_data = 4.56; 
+  RLPStream stream;
+  stream << double_data;
+  std::vector<byte> result = stream.out();
+  for(auto i : result){
+    platon::println(i);
+  }
+  double_data = 0;
+  fetch(RLP(result), double_data);
+  platon::println(double_data);
 }
 
 TEST_CASE(rlp, address) {
@@ -31,7 +183,18 @@ TEST_CASE(rlp, array) {
 }
 
 UNITTEST_MAIN() {
+  RUN_TEST(rlp, int8_t)
+  RUN_TEST(rlp, int16_t)
+  RUN_TEST(rlp, int32_t)
   RUN_TEST(rlp, int)
+  RUN_TEST(rlp, int64_t)
+  RUN_TEST(rlp, bool)
+  RUN_TEST(rlp, uint8_t)
+  RUN_TEST(rlp, uint16_t)
+  RUN_TEST(rlp, uint32_t)
+  RUN_TEST(rlp, uint64_t)
+  RUN_TEST(rlp, float)
+  RUN_TEST(rlp, double)
   RUN_TEST(rlp, address)
   RUN_TEST(rlp, array)
 }


### PR DESCRIPTION
1.RLP adds int type support 
2. Turn on the macro switch NDEBUG to remove invalid strings