### PR TITLE
replace platon_gas_price return type with u256

### DIFF
--- a/libraries/platonlib/include/platon/chain.hpp
+++ b/libraries/platonlib/include/platon/chain.hpp
@@ -8,10 +8,10 @@ extern "C" {
 /**
  * @brief Get the value of gas price
  *
- * @param void
- * @return the value of gas price
+ * @param gas_price The big-endian represents the gas price
+ * @return the length of gas price
  */
-uint64_t platon_gas_price();
+uint8_t platon_gas_price(uint8_t gas_price[32]);
 
 /**
  * @brief Get the height of the current block

--- a/libraries/platonlib/include/platon/chain_impl.hpp
+++ b/libraries/platonlib/include/platon/chain_impl.hpp
@@ -10,6 +10,17 @@
 namespace platon {
 
 /**
+ * @brief Get the value of gas price
+ *
+ * @return The value of gas price
+ */
+u256 platon_gas_price() {
+  byte gas_price[32];
+  ::platon_gas_price(gas_price);
+  return fromBigEndian<u256>(gas_price);
+}
+
+/**
  * @brief Get the unix timestamp of the current block
  *
  * @return The unix timestamp of the current block (second)


### PR DESCRIPTION
Fixes [#1147](https://github.com/PlatONnetwork/PlatON-Go/issues/1147)