### PR TITLE
added support for string literal conversion to u128 type Numbers

### DIFF
--- a/libraries/platonlib/include/platon/chain_impl.hpp
+++ b/libraries/platonlib/include/platon/chain_impl.hpp
@@ -77,8 +77,8 @@ bool platon_transfer(const Address& addr, const Energon& amount);
  */
 u128 platon_call_value() {
   byte val[16];
-  ::platon_call_value(val);
-  return fromBigEndian<u128>(val);
+  size_t len  = ::platon_call_value(val);
+  return fromBigEndian<u128>(bytesRef(val, len));
 }
 
 /**

--- a/libraries/platonlib/include/platon/common.h
+++ b/libraries/platonlib/include/platon/common.h
@@ -8,6 +8,7 @@
 #include <type_traits>
 #include <vector>
 #include "vector_ref.h"
+#include "panic.hpp"
 
 namespace platon {
 using u128 = __uint128_t;
@@ -153,3 +154,41 @@ inline T fromBigEndian(_In const& _bytes) {
   return ret;
 }
 }  // namespace platon
+
+
+/**
+ * @brief Converts a string to an integer of type u128.
+ * @param str_value The value string starts with a pointer.
+ * @param len Value string length.
+ * @return an integer of type u128.
+ */
+inline platon::u128 operator "" _u128 (const char *str_value, size_t len){
+  bool is_hex = false;
+  if(len > 2 && '0' == str_value[0] && 'x' == str_value[1] ){
+    is_hex = true;
+  } else {
+    for(int i = 0; i < len; ++i){
+      int temp = platon::fromHexChar(str_value[i]);
+      if(-1 == temp){
+        platon::internal::platon_throw("Not a valid numeric character");
+      }
+      if(temp > 9){
+        is_hex = true;
+        break;
+      }
+    }
+  }
+
+  platon::u128 result = 0;
+  if(is_hex) {
+    platon::bytes hex_bytes = platon::fromHex(str_value);
+    result = platon::fromBigEndian<platon::u128>(hex_bytes);
+  }else {
+    for(int i = 0; i < len; ++i){
+      int temp = platon::fromHexChar(str_value[i]);
+      result = result * 10 + temp;
+    }
+  }
+
+  return result;
+}

--- a/libraries/platonlib/include/platon/dispatcher.hpp
+++ b/libraries/platonlib/include/platon/dispatcher.hpp
@@ -36,6 +36,7 @@ void get_para(RLP& rlp, std::tuple<Args...>& t) {
 template <typename T>
 void platon_return(const T& t) {
   RLPStream rlp_stream;
+  rlp_stream.reserve(pack_size(t));
   rlp_stream << t;
   const bytesRef result = rlp_stream.out();
   ::platon_return(result.data(), result.size());

--- a/libraries/platonlib/include/platon/platon.hpp
+++ b/libraries/platonlib/include/platon/platon.hpp
@@ -16,3 +16,6 @@
 #include "platon/assert.hpp"
 #include "platon/chain_impl.hpp"
 #include "platon/exchange.hpp"
+#include "platon/db/array.hpp"
+#include "platon/db/map.hpp"
+#include "platon/db/multi_index.hpp"

--- a/libraries/platonlib/include/platon/storagetype.hpp
+++ b/libraries/platonlib/include/platon/storagetype.hpp
@@ -204,8 +204,8 @@ using Array = class StorageType<name, std::array<T, N>>;
 template <Name::Raw name, typename... Types>
 using Tuple = class StorageType<name, std::tuple<Types...>>;
 
-template <Name::Raw name, typename T>
-using Deque = class StorageType<name, std::deque<T>>;
+// template <Name::Raw name, typename T>
+// using Deque = class StorageType<name, std::deque<T>>;
 
 //    template <Name::Raw name,  typename T>
 //    using Queue = class StorageType<name, std::queue<T>>;

--- a/tests/unit/print_test.cpp
+++ b/tests/unit/print_test.cpp
@@ -1,3 +1,4 @@
+#undef NDEBUG
 #include "platon/print.hpp"
 #include "platon/common.h"
 #include "unit_test.hpp"
@@ -14,17 +15,17 @@ TEST_CASE(print, int) {
   DEBUG(test_int)
 }
 
-TEST_CASE(print, float) {
-  float test_float = 1.23;
-  platon::println(test_float);
-  DEBUG(test_float)
-}
+// TEST_CASE(print, float) {
+//   float test_float = 1.23;
+//   platon::println(test_float);
+//   DEBUG(test_float)
+// }
 
-TEST_CASE(print, double) {
-  double test_double = -4.56;
-  platon::println(test_double);
-  DEBUG(test_double)
-}
+// TEST_CASE(print, double) {
+//   double test_double = -4.56;
+//   platon::println(test_double);
+//   DEBUG(test_double)
+// }
 
 TEST_CASE(print, string) {
   std::string test_string = "string test";
@@ -35,13 +36,25 @@ TEST_CASE(print, string) {
 TEST_CASE(print, u128) {
   u128 i = 9999999;
   platon::println(i);
-  DEBUG(i)
+
+  u128 info = "1339673436730796483172139894692642816"_u128;
+  platon::println(info);
+
+  info = "0x01020300000000000000000000000000"_u128;
+  platon::println(info);
+
+  info = "66051"_u128;
+  platon::println(info);
+
+  info = "0x010203"_u128;
+  platon::println(info);
 }
+
 UNITTEST_MAIN() {
   RUN_TEST(print, char);
   RUN_TEST(print, int);
-  RUN_TEST(print, float);
-  RUN_TEST(print, double);
+  // RUN_TEST(print, float);
+  // RUN_TEST(print, double);
   RUN_TEST(print, string);
   RUN_TEST(print, u128);
 }


### PR DESCRIPTION
1. added support for string literal conversion to u128 type Numbers
2. Fix platon_call_value acquisition error
3. RLP serialization does not support STD ::deque
4. Add reserved storage space in platon_return for RLPStream
5. Expose array.hpp, map.hpp, and multi_index.hpp to the user