### PR TITLE
Add new type int128_t, support int128_t rlp encoding, printing, abi file display.

### DIFF
--- a/example/cross_call_contract.cpp
+++ b/example/cross_call_contract.cpp
@@ -45,6 +45,14 @@ CONTRACT user : public platon::Contract {
             return return_value;
         }
 
+         ACTION std::vector<my_message> call_direct(const std::string &target_address, const my_message &one_message,
+            uint64_t gas_value) {
+            auto result = make_address(target_address);
+            if(!result.second) return std::vector<my_message>();
+            std::vector<my_message> return_value;
+            auto call_result = platon_delegate_call<std::vector<my_message>>(result.first, gas_value, "add_message", one_message);
+            return call_result.first;
+         }
 };
 
-PLATON_DISPATCH(user, (init)(call_add_message)(delegate_call_add_message))
+PLATON_DISPATCH(user, (init)(call_add_message)(delegate_call_add_message)(call_direct))

--- a/libraries/platonlib/include/platon/RLP.h
+++ b/libraries/platonlib/include/platon/RLP.h
@@ -214,6 +214,7 @@ class RLP {
   explicit operator int() const { return toSignedInt<int>(); }
   explicit operator int32_t() const { return toSignedInt<int32_t>(); }
   explicit operator int64_t() const { return toSignedInt<int64_t>(); }
+  explicit operator int128_t() const { return toSignedInt<int128_t>(); }
   explicit operator float() const { return toFloat(); }
   explicit operator double() const { return toDouble(); }
   template <unsigned N>
@@ -358,10 +359,10 @@ class RLP {
 
   template <typename _T>
   _T toSignedInt(int _flags = Strict) const {
-    uint64_t u64_data = toInt<uint64_t>(_flags);
-    int64_t int64_data =
-        static_cast<int64_t>((u64_data >> 1) ^ -(u64_data & 1));
-    return static_cast<_T>(int64_data);
+    uint64_t u128_data = toInt<uint128_t>(_flags);
+    int128_t int128_data =
+        static_cast<int128_t>((u128_data >> 1) ^ -(u128_data & 1));
+    return static_cast<_T>(int128_data);
   }
 
   float toFloat(int _flags = Strict) const {
@@ -611,12 +612,13 @@ class RLPStream {
   RLPStream& append(uint32_t _s) { return append(bigint(_s)); }
   RLPStream& append(uint64_t _s) { return append(bigint(_s)); }
   RLPStream& append(bigint _i);
-  RLPStream& append(int8_t _c) { return append(int64_t(_c)); }
-  RLPStream& append(int16_t _s) { return append(int64_t(_s)); }
-  RLPStream& append(int _c) { return append(int64_t(_c)); }
-  RLPStream& append(int32_t _s) { return append(int64_t(_s)); }
-  RLPStream& append(int64_t _l) {
-    uint64_t _i = uint64_t((_l << 1) ^ (_l >> 63));
+  RLPStream& append(int8_t _c) { return append(int128_t(_c)); }
+  RLPStream& append(int16_t _s) { return append(int128_t(_s)); }
+  RLPStream& append(int _c) { return append(int128_t(_c)); }
+  RLPStream& append(int32_t _s) { return append(int128_t(_s)); }
+  RLPStream& append(int64_t _s) { return append(int128_t(_s)); }
+  RLPStream& append(int128_t _l) {
+    uint128_t _i = uint128_t((_l << 1) ^ (_l >> 127));
     return append(_i);
   }
   RLPStream& append(float _f) {

--- a/libraries/platonlib/include/platon/authority.hpp
+++ b/libraries/platonlib/include/platon/authority.hpp
@@ -57,7 +57,7 @@ void set_owner(const std::string &address = std::string()) {
     platon_addr = platon_caller();
   } else {
     auto result = make_address(address);
-    if (!result.second) platon_addr = result.first;
+    if (result.second) platon_addr = result.first;
   }
 
   StorageType<"platonowner"_n, Address> owner_addr;
@@ -87,7 +87,7 @@ bool is_owner(const std::string &addr = std::string()) {
     platon_addr = platon_origin();
   } else {
     auto result = make_address(addr);
-    if (!result.second) platon_addr = result.first;
+    if (result.second) platon_addr = result.first;
   }
 
   StorageType<"platonowner"_n, Address> owner_addr;
@@ -114,7 +114,7 @@ class WhiteList {
    */
   void Add(const std::string &addr) {
     auto result = make_address(addr);
-    if (!result.second) Add(result.first);
+    if (result.second) Add(result.first);
   }
 
   /**
@@ -131,7 +131,7 @@ class WhiteList {
    */
   void Delete(const std::string &addr) {
     auto result = make_address(addr);
-    if (!result.second) Delete(result.first);
+    if (result.second) Delete(result.first);
   }
 
   /**
@@ -149,7 +149,7 @@ class WhiteList {
    */
   bool Exists(const std::string &addr) {
     auto result = make_address(addr);
-    if (!result.second) return Exists(result.first);
+    if (result.second) return Exists(result.first);
     return false;
   }
 

--- a/libraries/platonlib/include/platon/cross_call.hpp
+++ b/libraries/platonlib/include/platon/cross_call.hpp
@@ -8,7 +8,6 @@
 #include "boost/fusion/algorithm/iteration/for_each.hpp"
 #include "boost/preprocessor/seq/for_each.hpp"
 
-
 #include "RLP.h"
 #include "chain.hpp"
 #include "common.h"
@@ -143,7 +142,7 @@ inline void get_call_output(T &t) {
  make_address("lax10jc0t4ndqarj4q6ujl3g3ycmufgc77epxg02lt"); auto result =
  platon_call<int>(address_pair.first,
   uint32_t(100), uint32_t(100), "add", 1,2,3);
-  if(!result.secod){
+  if(!result.second){
     platon_throw("cross call fail");
   }
  * @endcode
@@ -188,7 +187,7 @@ inline decltype(auto) platon_call(const Address &addr, const value_type &value,
  make_address("lax10jc0t4ndqarj4q6ujl3g3ycmufgc77epxg02lt"); auto result =
  platon_delegate_call<int>(address_pair.first,
   uint32_t(100), "add", 1,2,3);
-  if(!result.secod){
+  if(!result.secnod){
     platon_throw("cross call fail");
   }
 

--- a/libraries/platonlib/include/platon/dispatcher.hpp
+++ b/libraries/platonlib/include/platon/dispatcher.hpp
@@ -26,6 +26,12 @@ inline byte* get_input(size_t& len) {
 
 template <typename... Args>
 void get_para(RLP& rlp, std::tuple<Args...>& t) {
+  using tuple_args = typename std::remove_reference<decltype(t)>::type;
+  if (std::tuple_size<tuple_args>::value != rlp.itemCount() - 1) {
+    platon::internal::platon_throw(
+        "The number of method parameters does not match\n");
+  }
+
   int vect_index = 1;
   boost::fusion::for_each(t, [&](auto& i) {
     fetch(rlp[vect_index], i);
@@ -118,7 +124,7 @@ void execute_action(RLP& rlp, void (T::*func)(Args...)) {
     uint64_t method = 0;                                     \
     fetch(rlp[0], method);                                   \
     if (0 == method) {                                       \
-      platon::internal::platon_throw("valid method\n");      \
+      platon::internal::platon_throw("invalid method\n");    \
     }                                                        \
     PLATON_DISPATCH_HELPER(TYPE, MEMBERS)                    \
     else {                                                   \

--- a/libraries/platonlib/include/platon/print.hpp
+++ b/libraries/platonlib/include/platon/print.hpp
@@ -16,20 +16,30 @@ string to_string(uint128_t value) {
   reverse(result.begin(), result.end());
   return result;
 }
+
+string to_string(int128_t value) {
+  std::string prefix;
+  uint128_t absolute_value = value;
+  if (value < 0) {
+    absolute_value = static_cast<uint128_t>(0 - value);
+    prefix = "-";
+  }
+  return prefix + to_string(absolute_value);
+}
+
 }  // namespace std
+
 namespace platon {
 
-std::string all_info;
+inline void print(std::string& all_info, const char* ptr) { all_info += ptr; }
 
-inline void print(const char* ptr) { all_info += ptr; }
-
-inline void print(std::string info) { all_info += info; }
+inline void print(std::string& all_info, std::string info) { all_info += info; }
 
 template <typename T,
           class = typename std::enable_if<
               std::numeric_limits<std::decay_t<T>>::is_integer ||
               std::numeric_limits<std::decay_t<T>>::is_iec559>::type>
-inline void print(const T num) {
+inline void print(std::string& all_info, const T num) {
   if constexpr (std::is_same<T, char>::value) {
     all_info += num;
   } else if constexpr (std::is_same<T, bool>::value) {
@@ -45,29 +55,23 @@ inline void print(const T num) {
 }
 
 template <typename Arg, typename... Args>
-void print(Arg&& a, Args&&... args) {
-  print(std::forward<Arg>(a));
-  print(" ");
-  print(std::forward<Args>(args)...);
+void print(std::string& all_info, Arg&& a, Args&&... args) {
+  print(all_info, std::forward<Arg>(a));
+  print(all_info, " ");
+  print(all_info, std::forward<Args>(args)...);
 }
 
 template <typename Arg, typename... Args>
 void println(Arg&& a, Args&&... args) {
-  all_info = "";
-  print(std::forward<Arg>(a), std::forward<Args>(args)...);
+#ifndef NDEBUG
+  std::string all_info;
+  print(all_info, std::forward<Arg>(a), std::forward<Args>(args)...);
   printf("%s\t\n", all_info.c_str());
+#endif
 }
 
-#ifdef NDEBUG
-
-  #define DEBUG(...) ((void)0);
-
-#else
-
-  #define DEBUG(...)                                                      \
-    platon::println("line", __LINE__, "file", __FILE__, "func", __func__, \
-                    ##__VA_ARGS__);
-
-#endif
+#define DEBUG(...)                                                      \
+  platon::println("line", __LINE__, "file", __FILE__, "func", __func__, \
+                  ##__VA_ARGS__);
 
 }  // namespace platon

--- a/libraries/platonlib/include/platon/rlp_size.hpp
+++ b/libraries/platonlib/include/platon/rlp_size.hpp
@@ -131,16 +131,18 @@ class RLPSize {
     return *this;
   }
 
-  RLPSize& append(int8_t s) { return append(int64_t(s)); }
+  RLPSize& append(int8_t s) { return append(int128_t(s)); }
 
-  RLPSize& append(int16_t s) { return append(int64_t(s)); }
+  RLPSize& append(int16_t s) { return append(int128_t(s)); }
 
-  RLPSize& append(int c) { return append(int64_t(c)); }
+  RLPSize& append(int c) { return append(int128_t(c)); }
 
-  RLPSize& append(int32_t c) { return append(int64_t(c)); }
+  RLPSize& append(int32_t c) { return append(int128_t(c)); }
 
-  RLPSize& append(int64_t c) {
-    uint64_t i = uint64_t((c << 1) ^ (c >> 63));
+  RLPSize& append(int64_t c) { return append(int128_t(c));}
+
+  RLPSize& append(int128_t c) {
+    uint128_t i = uint128_t((c << 1) ^ (c >> 127));
     return append(i);
   }
 

--- a/tests/unit/print_test.cpp
+++ b/tests/unit/print_test.cpp
@@ -1,4 +1,5 @@
 #undef NDEBUG
+#define TESTNET
 #include "platon/common.h"
 #include "platon/fixedhash.hpp"
 #include "platon/print.hpp"
@@ -51,11 +52,28 @@ TEST_CASE(print, u128) {
   platon::println(info);
 }
 
-TEST_CASE(debug, h64){
+TEST_CASE(print, int128_t) {
+  u128 i = 9999999;
+  platon::println(i);
+
+  u128 info = "1339673436730796483172139894692642816"_u128;
+  int128_t signed_info = 0 - int128_t(info);
+  platon::println(int128_t(info));
+  platon::println(signed_info);
+}
+
+TEST_CASE(print, address){
     h64 h64_data("0x0102030405060708");
-    printf("h64_data:%s\t\n", h64_data.toString().c_str());
+    platon::println("h64_data:", h64_data.toString());
     auto address_info = make_address("lax10jc0t4ndqarj4q6ujl3g3ycmufgc77epxg02lt");
-    printf("address:%s\t\n", address_info.first.toString().c_str());
+    platon::println("check result:", address_info.second ? "true" : "false");
+    platon::println("address:", address_info.first.toString());
+    auto address_same_info = make_address("lax10jc0t4ndqarj4q6ujl3g3ycmufgc77epxg02lt");
+    platon::println("check same:", address_info.first == address_same_info.first ? "true" : "false");
+    platon::println("check not same:", address_info.first != address_same_info.first ? "true" : "false");
+    auto address_other_info = make_address("lax1uqug0zq7rcxddndleq4ux2ft3tv6dqljphydrl");
+    platon::println("check same:", address_info.first == address_other_info.first ? "true" : "false");
+    platon::println("check not same:", address_info.first != address_other_info.first ? "true" : "false");
 }
 
 UNITTEST_MAIN() {
@@ -65,5 +83,6 @@ UNITTEST_MAIN() {
   // RUN_TEST(print, double);
   RUN_TEST(print, string);
   RUN_TEST(print, u128);
-  RUN_TEST(debug, h64);
+  RUN_TEST(print, int128_t);
+  RUN_TEST(print, address);
 }

--- a/tests/unit/rlp_test.cpp
+++ b/tests/unit/rlp_test.cpp
@@ -284,6 +284,41 @@ TEST_CASE(rlp, int64_t_reserve) {
   ASSERT_EQ(int64_t_data, 9223372036854775807, int64_t_data);
 }
 
+TEST_CASE(rlp, int128_t) {
+  const char* fn = "int128_t";
+  int128_t int128_t_data = 0x7fffffffffffffff;
+  size_t size = pack_size(int128_t_data);
+  platon_debug_gas(__LINE__, fn, strlen(fn));
+  RLPStream stream;
+  stream << int128_t_data;
+  bytesRef result = stream.out();
+  platon_debug_gas(__LINE__, fn, strlen(fn));
+  ASSERT_EQ(size, result.size());
+  print_rlp_code("int128_t", int128_t_data, result);
+  int128_t_data = 0;
+  fetch(RLP(result), int128_t_data);
+  platon::println(int128_t_data);
+  ASSERT_EQ(int128_t_data, 9223372036854775807, int128_t_data);
+}
+
+TEST_CASE(rlp, int128_t_reserve) {
+  const char* fn = "int128_t_reserve";
+  int128_t int128_t_data = 0x7fffffffffffffff;
+  size_t size = pack_size(int128_t_data);
+  platon_debug_gas(__LINE__, fn, strlen(fn));
+  RLPStream stream;
+  stream.reserve(size);
+  stream << int128_t_data;
+  bytesRef result = stream.out();
+  platon_debug_gas(__LINE__, fn, strlen(fn));
+  ASSERT_EQ(size, result.size());
+  print_rlp_code("int128_t", int128_t_data, result);
+  int128_t_data = 0;
+  fetch(RLP(result), int128_t_data);
+  platon::println(int128_t_data);
+  ASSERT_EQ(int128_t_data, 9223372036854775807, int128_t_data);
+}
+
 TEST_CASE(rlp, bool) {
   const char* fn = "bool";
   bool bool_data = true;
@@ -847,6 +882,8 @@ UNITTEST_MAIN() {
   RUN_TEST(rlp, int32_t_reserve);
   RUN_TEST(rlp, int64_t);
   RUN_TEST(rlp, int64_t_reserve);
+  RUN_TEST(rlp, int128_t);
+  RUN_TEST(rlp, int128_t_reserve);
   RUN_TEST(rlp, bool);
   RUN_TEST(rlp, bool_reserve);
   RUN_TEST(rlp, uint8_t);


### PR DESCRIPTION
1、Add new type int128_t, support int128_t rlp encoding, printing, abi file display.
2、The new platon_assert will not print out information to the log in release mode.
3、Fix the bug of setting and judging the address of ower's first pass function.
