### PR TITLE
The -z optimization of wasm-opt was too aggressive, which caused the …

### DIFF
--- a/tools/platon-cpp/platon-cpp.cpp
+++ b/tools/platon-cpp/platon-cpp.cpp
@@ -117,7 +117,7 @@ int main(int argc, char **argv) {
   int result = GenerateWASM(Option, M.get());
   if (0 == result) {
     std::string command =
-        "wasm-opt -Oz -o " + Option.Output + " " + Option.Output;
+        "wasm-opt -O2 -o " + Option.Output + " " + Option.Output;
     system(command.c_str());
   }
 


### PR DESCRIPTION
The -z optimization of wasm-opt was too aggressive, which caused the effective logic in the loop to be optimized away, which did not conform to the original actual code logic.